### PR TITLE
Ripple-Insert-Recording - fügt eine neue Aufnahme ins Projekt ein #72

### DIFF
--- a/Scripts/ultraschall_InsertRecording.lua
+++ b/Scripts/ultraschall_InsertRecording.lua
@@ -1,0 +1,82 @@
+--[[
+################################################################################
+# 
+# Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# 
+################################################################################
+]]
+
+-- Meo Mespotine 5th of February 2019
+
+-- Inserts recording at EditCursorposition
+-- will keep a gap until recording is stopped and close the gap after that
+-- good for "Of, I forgot to add this or that to include in the middle of my recording"-usecases
+
+dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+
+function MoveUntilStop()
+  -- moves items, track-envelope-points, regions and markers after current recording-position to be always at least 
+  -- 4 seconds away until recording stops
+  if position<=reaper.GetPlayPosition()+4 and reaper.GetPlayState()&2==0 then
+    retval = ultraschall.MoveMediaItemsAfter_By(position, 4, trackstring)
+    retval = ultraschall.MoveMarkersBy(position, reaper.GetProjectLength()+1, 4, false)
+    retval = ultraschall.MoveRegionsBy(position, reaper.GetProjectLength(), 4, false)
+    for i=0, reaper.CountTracks(0)-1 do
+      ultraschall.MoveTrackEnvelopePointsBy(position, reaper.GetProjectLength()+1, 4, reaper.GetTrack(0,i), false)
+    end
+    position=position+4
+  end  
+  if reaper.GetPlayState()&4==4 then reaper.defer(MoveUntilStop) else 
+    -- if recording stops, move items, trackenvelope-points, regions and markers after current recording-position
+    -- back to close the 4+ second gap
+    stopposition=reaper.GetPlayPosition()
+    Aretval = ultraschall.MoveMediaItemsAfter_By(position, -(position-stopposition), trackstring)
+    retval = ultraschall.MoveMarkersBy(position, reaper.GetProjectLength()+1, -(position-stopposition), false)
+    for i=0, reaper.CountTracks(0)-1 do
+      ultraschall.MoveTrackEnvelopePointsBy(position, reaper.GetProjectLength()+1, -(position-stopposition), reaper.GetTrack(0,i), false)
+    end
+    reaper.UpdateArrange()
+  end
+end
+
+if reaper.GetPlayState()~=0 then 
+  reaper.CSurf_OnStop() 
+  --elseif reaper.GetCursorPosition()>=reaper.GetProjectLength() then
+  --  reaper.CSurf_OnRecord()
+else
+  -- get currently existing tracks and current edit-cursorposition
+  trackstring=ultraschall.CreateTrackString_AllTracks()
+  position=reaper.GetCursorPosition()
+
+  -- move items, trackenvelope-points, regions and markers after current editcursor-position by 
+  -- 4 seconds toward the end of the project to make room for the recording
+  retval, MediaItemArray = ultraschall.SplitMediaItems_Position(position, trackstring, false)
+  retval = ultraschall.MoveMediaItemsAfter_By(position, 4, trackstring)
+  retval = ultraschall.MoveMarkersBy(position, reaper.GetProjectLength()+1, 4, false)
+  for i=0, reaper.CountTracks(0)-1 do
+    ultraschall.MoveTrackEnvelopePointsBy(position, reaper.GetProjectLength()+1, 4, reaper.GetTrack(0,i), false)
+  end
+  
+  position=position+4
+  reaper.CSurf_OnRecord()
+  MoveUntilStop()  
+end
+

--- a/reaper-kb.ini
+++ b/reaper-kb.ini
@@ -123,49 +123,53 @@ SCR 4 0 Ultraschall_Shuttle_Backward "Custom: ULTRASCHALL: Shuttle Backward" ult
 SCR 516 0 Ultraschall_Shuttle_Forward "Custom: ULTRASCHALL: Shuttle Forward" ultraschall_shuttle_forward.lua
 SCR 4 0 Ultraschall_Shuttle_Pause "Custom: ULTRASCHALL: Shuttle Pause" ultraschall_shuttle_pause.lua
 SCR 4 0 Ultraschall_Shuttle_Background_Script "Custom: ULTRASCHALL: Shuttle Background Script" ultraschall_shuttle_background_script.lua
-SCR 4 0 Ultraschall_Ultraschall_Api_Functions_Documentation "Custom: Documentation: Ultraschall-API-Functions-reference" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Ultraschall_Api_Functions_Reference.lua
-SCR 4 0 Ultraschall_Ultraschall_Api_Concepts_Documentation "Custom: Documentation: Ultraschall-API-Concepts-reference" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua
-SCR 4 0 Ultraschall_Reaper_Api_Documentation "Custom: Documentation: Reaper Documentation(Ultraschall version)" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Reaper_Api_Documentation.lua
-SCR 4 0 RS1ee9bb229dabffe151848d7efa3c10f748e1a1cf "Custom: lyrics.lua" Cockos/lyrics.lua
-SCR 4 32060 RS7d3c_1ee9bb229dabffe151848d7efa3c10f748e1a1cf "Custom: lyrics.lua" Cockos/lyrics.lua
-SCR 4 0 RS9fcfb9c005f1d526d1cc21cb90f1dc33560cb4a0 "Custom: ultraschall_Help_Ultraschall_Api_Functions_Reference.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Februar2019-Ultraschall-Inspector\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Ultraschall_Api_Functions_Reference.lua
-SCR 4 0 RS66e201302b9c921cfe8650d732a45b3064c9de90 "Custom: ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Februar2019-Ultraschall-Inspector\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua
-SCR 4 0 RSa86d32154e7273072272ed82e74cf11cf4b8220a "Custom: ultraschall_Help_Reaper_Api_Documentation.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Februar2019-Ultraschall-Inspector\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Reaper_Api_Documentation.lua
-KEY 9 219 0 0
-KEY 5 86 0 0
-KEY 1 70 0 0
-KEY 5 69 0 0
-KEY 1 86 0 0
-KEY 9 221 0 0
-KEY 255 218 0 0
-KEY 1 87 0 0
-KEY 9 32814 0 0
+SCR 4 0 Ultraschall_Add_ExampleScripts_To_Reaper "Custom: ULTRASCHALL: Add Ultraschall-API examplescripts to Reaper" ultraschall_Add_ExampleScripts_To_Reaper.lua
+SCR 4 0 Ultraschall_Help_Reaper_Api_Documentation "Custom: ULTRASCHALL: Open Reaper-API Documentation (Ultraschall version)" ultraschall_Help_Reaper_Api_Documentation.lua
+SCR 4 0 Ultraschall_Help_Reaper_Api_Video_Documentation "Custom: ULTRASCHALL: Open Reaper-Video-API Documentation (Ultraschall version)" ultraschall_Help_Reaper_Api_Video_Documentation.lua
+SCR 4 0 Ultraschall_Help_Reaper_Api_Web_Documentation "Custom: ULTRASCHALL: Open Reaper-WebRemoteControl-API Documentation (Ultraschall version)" ultraschall_Help_Reaper_Api_Web_Documentation.lua
+SCR 4 0 Ultraschall_Help_Reaper_ConfigVars_Documentation "Custom: ULTRASCHALL: Open Reaper-Configuration-Variables Documentation (Ultraschall version)" ultraschall_Help_Reaper_ConfigVars_Documentation.lua
+SCR 4 0 Ultraschall_Help_Ultraschall_Api_Functions_Reference "Custom: ULTRASCHALL: Open Ultraschall-API Documentation" ultraschall_Help_Ultraschall_Api_Functions_Reference.lua
+SCR 4 0 Ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts "Custom: ULTRASCHALL: Open Ultraschall-API-Concepts Documentation" ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua
+SCR 4 0 Ultraschall_OpenFolder_Api_Documentation "Custom: ULTRASCHALL: Open Ultraschall-API-Documentation folder" ultraschall_OpenFolder_Api_Documentation.lua
+SCR 4 0 Ultraschall_OpenFolder_Api_ExampleScripts "Custom: ULTRASCHALL: Open Ultraschall-API-Examplescripts folder" ultraschall_OpenFolder_Api_ExampleScripts.lua
+SCR 4 0 ultraschall_Remove_ExampleScripts_From_Reaper "Custom: ULTRASCHALL: Remove Ultraschall-API examplescripts from Reaper" ultraschall_Remove_ExampleScripts_From_Reaper.lua
+SCR 4 0 Ultraschall_Jump_Right_To_Next_Itemedge "Custom: ultraschall_jump_right_to_next_itemedge.lua" ultraschall_jump_right_to_next_itemedge.lua
+SCR 4 0 Ultraschall_Jump_Left_To_Next_Itemedge "Custom: ultraschall_jump_left_to_next_itemedge.lua" ultraschall_jump_left_to_next_itemedge.lua
+KEY 25 83 0 0
+KEY 0 123 0 0
 KEY 9 32802 0 0
+KEY 0 61 0 0
+KEY 0 39 0 0
+KEY 5 69 0 0
+KEY 0 34 0 0
+KEY 1 70 0 0
+KEY 8 93 0 0
+KEY 5 86 0 0
+KEY 8 91 0 0
+KEY 1 87 0 0
 KEY 25 32806 0 0
+KEY 0 126 0 0
+KEY 0 96 0 0
+KEY 255 218 0 0
+KEY 1 84 0 0
+KEY 1 86 0 0
 KEY 25 32808 0 0
 KEY 5 70 0 0
+KEY 9 32814 0 0
 KEY 0 125 0 0
-KEY 0 123 0 0
-KEY 0 34 0 0
-KEY 0 39 0 0
-KEY 1 84 0 0
-KEY 0 126 0 0
-KEY 0 61 0 0
-KEY 0 96 0 0
-KEY 25 83 0 0
 KEY 176 1 26 0
 KEY 176 2 34 0
 KEY 176 3 42 0
 KEY 176 4 50 0
 KEY 255 216 988 0
 KEY 255 248 989 0
-KEY 176 432 990 0
 KEY 255 251 990 0
-KEY 176 182 992 0
+KEY 176 432 990 0
 KEY 176 1080 992 0
+KEY 176 182 992 0
 KEY 176 433 996 0
-KEY 255 8650 998 0
 KEY 176 1204 998 0
+KEY 255 8650 998 0
 KEY 17 65 1155 0
 KEY 1 123 40009 0
 KEY 13 83 40022 0
@@ -175,11 +179,11 @@ KEY 1 32807 40105 0
 KEY 5 220 40113 0
 KEY 5 84 40142 0
 KEY 0 63 40151 0
-KEY 9 190 40175 0
-KEY 17 8 40201 0
+KEY 8 46 40175 0
 KEY 144 16274 40201 0
+KEY 17 8 40201 0
 KEY 17 34 40295 0
-KEY 17 189 40295 0
+KEY 16 45 40295 0
 KEY 1 57 40296 0
 KEY 1 48 40297 0
 KEY 9 8 40307 0
@@ -192,9 +196,9 @@ KEY 1 117 40422 0
 KEY 0 93 40434 0
 KEY 1 1048 40434 0
 KEY 5 121 40477 0
-KEY 17 188 40605 0
-KEY 1 73 40625 0
+KEY 16 44 40605 0
 KEY 144 16268 40625 0
+KEY 1 73 40625 0
 KEY 1 79 40626 0
 KEY 144 16269 40626 0
 KEY 17 73 40630 0
@@ -202,16 +206,16 @@ KEY 17 79 40631 0
 KEY 17 70 40638 0
 KEY 17 76 40651 0
 KEY 9 76 40687 0
-KEY 1 32814 40697 0
 KEY 1 8 40697 0
+KEY 1 32814 40697 0
 KEY 1 83 40759 0
-KEY 17 190 40867 0
+KEY 16 46 40867 0
 KEY 5 78 40936 0
-KEY 17 32806 41167 0
-KEY 17 32808 41168 0
+KEY 17 32806 0 0
+KEY 21 37 41167 0
+KEY 17 32808 0 0
+KEY 21 39 41168 0
 KEY 21 68 41172 0
-KEY 17 32807 41249 0
-KEY 17 32805 41250 0
 KEY 9 49 41357 0
 KEY 21 72 42307 0
 KEY 1 65 _Ultraschall_Play_From_Editcursor_Position 0
@@ -227,16 +231,16 @@ KEY 5 79 _Ultraschall_PlayFromOutpoint 0
 KEY 1 107 _Ultraschall_Zoom_In_Horizontal 0
 KEY 1 109 _Ultraschall_Zoom_Out_Horizontal 0
 KEY 0 91 _Ultraschall_Zoom_Out_Horizontal 0
-KEY 144 16258 _Ultraschall_Set_Edit 0
 KEY 1 69 _Ultraschall_Set_Edit 0
+KEY 144 16258 _Ultraschall_Set_Edit 0
 KEY 17 77 _Ultraschall_Insert_Chapter_Marker_Back_In_Time 0
 KEY 5 8 _Ultraschall_Delete_Last_Marker 0
-KEY 144 16256 _Ultraschall_Set_Marker 0
 KEY 1 77 _Ultraschall_Set_Marker 0
+KEY 144 16256 _Ultraschall_Set_Marker 0
 KEY 5 77 _Ultraschall_Set_NamedMarker 0
+KEY 144 16290 _Ultraschall_Safemode_Start_Stop 0
 KEY 144 16270 _Ultraschall_Safemode_Start_Stop 0
 KEY 1 13 _Ultraschall_Safemode_Start_Stop 0
-KEY 144 16290 _Ultraschall_Safemode_Start_Stop 0
 KEY 1 32 _Ultraschall_Safemode_Start_Pause 0
 KEY 144 16291 _Ultraschall_Safemode_Start_Pause 0
 KEY 144 16271 _Ultraschall_Safemode_Start_Pause 0
@@ -272,8 +276,8 @@ KEY 1 113 _Ultraschall_Snapshot_2 0
 KEY 1 112 _Ultraschall_Snapshot_1 0
 KEY 1 116 _Ultraschall_Snapshot_Editor 0
 KEY 17 72 _Ultraschall_Toggle_Peak_Gain_Normal_Max 0
-KEY 9 70 _Ultraschall_Toggle_Follow 0
 KEY 9 1034 _Ultraschall_Toggle_Follow 0
+KEY 9 70 _Ultraschall_Toggle_Follow 0
 KEY 1 66 _Ultraschall_Set_Next_Planned_Marker 0
 KEY 9 89 _Ultraschall_Mute_Selected_Items_In_Time_Range 0
 KEY 13 89 _Ultraschall_Unmute_Selected_Items_In_Time_Range 0
@@ -281,21 +285,21 @@ KEY 5 72 _Ultraschall_Toggle_Envelope_Height 0
 KEY 29 85 _Ultraschall_Mastermind 0
 KEY 1 90 _Ultraschall_Toggle_Arrange_Zoom 0
 KEY 0 43 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
-KEY 13 187 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
+KEY 8 43 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
 KEY 1 32806 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
-KEY 0 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
-KEY 9 189 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
+KEY 8 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 1 32808 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
+KEY 0 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 5 65 _Ultraschall_Toggle_All_Track_Recarm_States 0
 KEY 9 84 _Ultraschall_Insert_And_Arm_New_Audio_Track 0
 KEY 9 77 _Ultraschall_Set_Marker_Play 0
 KEY 13 77 _Ultraschall_Set_Namedmarker_Play 0
 KEY 9 69 _Ultraschall_Set_Edit_Play 0
-KEY 255 250 _Ultraschall_Zoomlimiter 0
 KEY 255 200 _Ultraschall_Zoomlimiter 0
+KEY 255 250 _Ultraschall_Zoomlimiter 0
 KEY 1 1034 _Ultraschall_Go_To_Cursor 0
 KEY 17 74 _Ultraschall_Toggle_Playrate 0
-KEY 25 189 _Ultraschall_Zoom_Out_Centered_Cursorposition 0
+KEY 24 45 _Ultraschall_Zoom_Out_Centered_Cursorposition 0
 KEY 1 32804 _Ultraschall_Go_To_Start_Of_Project 0
 KEY 17 87 _Ultraschall_Go_To_Start_Of_Project 0
 KEY 1 32803 _Ultraschall_Go_To_End_Of_Project 0
@@ -306,3 +310,5 @@ KEY 16 228 _Ultraschall_Zoom_to_Region_at_Edit_Cursor 0
 KEY 1 74 _Ultraschall_Shuttle_Backward 0
 KEY 1 76 _Ultraschall_Shuttle_Forward 0
 KEY 1 75 _Ultraschall_Shuttle_Pause 0
+KEY 17 32807 _Ultraschall_Jump_Right_To_Next_Itemedge 0
+KEY 17 32805 _Ultraschall_Jump_Left_To_Next_Itemedge 0

--- a/reaper-kb.ini
+++ b/reaper-kb.ini
@@ -105,7 +105,7 @@ SCR 4 0 Ultraschall_Go_To_Cursor "Custom: ULTRASCHALL: Go to Cursor" ultraschall
 SCR 4 0 Ultraschall_Toggle_Playrate "Custom: ULTRASCHALL: Toggle playrate" ultraschall_toggle_playrate.lua
 SCR 4 0 Ultraschall_ZoomOut_Limiter "Custom: ULTRASCHALL: Zoom out limited to projectend" ultraschall_zoom_out_limiter.lua
 ACT 1 0 "Ultraschall_Zoom_Out_Centered_Cursorposition" "Custom: ULTRASCHALL: zoom out centered to cursorposition (unlimited)" _WOL_SETHZOOMC_EDITPLAYCUR 1011 _WOL_SETHZOOMC_MOUSECUR
-SCR 4 0 Ultraschall_State_Inspector "Custom: ULTRASCHALL Toolbox: State Inspector (Developer)" ultraschall_StateInspector.lua
+SCR 4 0 Ultraschall_State_Inspector "Custom: ULTRASCHALL Toolbox: State Inspector (Developer)" Ultraschall_StateInspector/ultraschall_StateInspector.lua
 SCR 4 0 Ultraschall_Turn_Off_Followmode "Custom: ULTRASCHALL: Turn off Followmode" ultraschall_turn_off_follow.lua
 SCR 4 0 Ultraschall_Turn_On_Followmode "Custom: ULTRASCHALL: Turn on Followmode" ultraschall_turn_on_follow.lua
 ACT 0 0 "Ultraschall_Go_To_Start_Of_Project" "Custom: ULTRASCHALL: Go to start of project" 40042 _Ultraschall_Turn_Off_Followmode
@@ -123,12 +123,14 @@ SCR 4 0 Ultraschall_Shuttle_Backward "Custom: ULTRASCHALL: Shuttle Backward" ult
 SCR 516 0 Ultraschall_Shuttle_Forward "Custom: ULTRASCHALL: Shuttle Forward" ultraschall_shuttle_forward.lua
 SCR 4 0 Ultraschall_Shuttle_Pause "Custom: ULTRASCHALL: Shuttle Pause" ultraschall_shuttle_pause.lua
 SCR 4 0 Ultraschall_Shuttle_Background_Script "Custom: ULTRASCHALL: Shuttle Background Script" ultraschall_shuttle_background_script.lua
-SCR 4 0 RSac7acc13ffc36a55de5610546c1e145073ac546a "Custom: ultraschall_Help_Ultraschall_Api_Functions_Reference.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Januar2019-RippleInsertRecording\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Ultraschall_Api_Functions_Reference.lua
-SCR 4 0 RS21fd22dc9bf9a2dd8e3f0f091a6fefe12d2def6b "Custom: ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Januar2019-RippleInsertRecording\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua
-SCR 4 0 RS3ed126b5b32884379d58eea488603b88c85a618e "Custom: ultraschall_Help_Reaper_Api_Documentation.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Januar2019-RippleInsertRecording\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Reaper_Api_Documentation.lua
-SCR 4 0 Ultraschall_RippleInsertRecording "Custom: ULTRASCHALL: Insert recording at editcursorposition without creating takes(ripple insert recording)" ultraschall_InsertRecording.lua
+SCR 4 0 Ultraschall_Ultraschall_Api_Functions_Documentation "Custom: Documentation: Ultraschall-API-Functions-reference" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Ultraschall_Api_Functions_Reference.lua
+SCR 4 0 Ultraschall_Ultraschall_Api_Concepts_Documentation "Custom: Documentation: Ultraschall-API-Concepts-reference" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua
+SCR 4 0 Ultraschall_Reaper_Api_Documentation "Custom: Documentation: Reaper Documentation(Ultraschall version)" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Reaper_Api_Documentation.lua
 SCR 4 0 RS1ee9bb229dabffe151848d7efa3c10f748e1a1cf "Custom: lyrics.lua" Cockos/lyrics.lua
 SCR 4 32060 RS7d3c_1ee9bb229dabffe151848d7efa3c10f748e1a1cf "Custom: lyrics.lua" Cockos/lyrics.lua
+SCR 4 0 RS9fcfb9c005f1d526d1cc21cb90f1dc33560cb4a0 "Custom: ultraschall_Help_Ultraschall_Api_Functions_Reference.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Februar2019-Ultraschall-Inspector\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Ultraschall_Api_Functions_Reference.lua
+SCR 4 0 RS66e201302b9c921cfe8650d732a45b3064c9de90 "Custom: ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Februar2019-Ultraschall-Inspector\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua
+SCR 4 0 RSa86d32154e7273072272ed82e74cf11cf4b8220a "Custom: ultraschall_Help_Reaper_Api_Documentation.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Februar2019-Ultraschall-Inspector\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Reaper_Api_Documentation.lua
 KEY 9 219 0 0
 KEY 5 86 0 0
 KEY 1 70 0 0
@@ -159,11 +161,11 @@ KEY 255 216 988 0
 KEY 255 248 989 0
 KEY 176 432 990 0
 KEY 255 251 990 0
-KEY 176 1080 992 0
 KEY 176 182 992 0
+KEY 176 1080 992 0
 KEY 176 433 996 0
-KEY 176 1204 998 0
 KEY 255 8650 998 0
+KEY 176 1204 998 0
 KEY 17 65 1155 0
 KEY 1 123 40009 0
 KEY 13 83 40022 0
@@ -176,8 +178,8 @@ KEY 0 63 40151 0
 KEY 9 190 40175 0
 KEY 17 8 40201 0
 KEY 144 16274 40201 0
-KEY 17 189 40295 0
 KEY 17 34 40295 0
+KEY 17 189 40295 0
 KEY 1 57 40296 0
 KEY 1 48 40297 0
 KEY 9 8 40307 0
@@ -200,8 +202,8 @@ KEY 17 79 40631 0
 KEY 17 70 40638 0
 KEY 17 76 40651 0
 KEY 9 76 40687 0
-KEY 1 8 40697 0
 KEY 1 32814 40697 0
+KEY 1 8 40697 0
 KEY 1 83 40759 0
 KEY 17 190 40867 0
 KEY 5 78 40936 0
@@ -213,8 +215,8 @@ KEY 17 32805 41250 0
 KEY 9 49 41357 0
 KEY 21 72 42307 0
 KEY 1 65 _Ultraschall_Play_From_Editcursor_Position 0
-KEY 0 228 _Ultraschall_ZoomToSelection 0
 KEY 9 32801 _Ultraschall_ZoomToSelection 0
+KEY 0 228 _Ultraschall_ZoomToSelection 0
 KEY 25 82 _Ultraschall_ResetPlaybackRate_and_RenderProject 0
 KEY 17 83 _Ultraschall_Slice_and_AddMetadata 0
 KEY 17 80 _Ultraschall_SkipLoopPlayback 0
@@ -223,21 +225,21 @@ KEY 1 80 _Ultraschall_SkipLoopPlayback_Absolute 0
 KEY 5 73 _Ultraschall_PlayFromInpoint 0
 KEY 5 79 _Ultraschall_PlayFromOutpoint 0
 KEY 1 107 _Ultraschall_Zoom_In_Horizontal 0
-KEY 0 91 _Ultraschall_Zoom_Out_Horizontal 0
 KEY 1 109 _Ultraschall_Zoom_Out_Horizontal 0
+KEY 0 91 _Ultraschall_Zoom_Out_Horizontal 0
 KEY 144 16258 _Ultraschall_Set_Edit 0
 KEY 1 69 _Ultraschall_Set_Edit 0
 KEY 17 77 _Ultraschall_Insert_Chapter_Marker_Back_In_Time 0
 KEY 5 8 _Ultraschall_Delete_Last_Marker 0
-KEY 1 77 _Ultraschall_Set_Marker 0
 KEY 144 16256 _Ultraschall_Set_Marker 0
+KEY 1 77 _Ultraschall_Set_Marker 0
 KEY 5 77 _Ultraschall_Set_NamedMarker 0
+KEY 144 16270 _Ultraschall_Safemode_Start_Stop 0
 KEY 1 13 _Ultraschall_Safemode_Start_Stop 0
 KEY 144 16290 _Ultraschall_Safemode_Start_Stop 0
-KEY 144 16270 _Ultraschall_Safemode_Start_Stop 0
 KEY 1 32 _Ultraschall_Safemode_Start_Pause 0
-KEY 144 16271 _Ultraschall_Safemode_Start_Pause 0
 KEY 144 16291 _Ultraschall_Safemode_Start_Pause 0
+KEY 144 16271 _Ultraschall_Safemode_Start_Pause 0
 KEY 1 49 _Ultraschall_Select_Track1 0
 KEY 1 50 _Ultraschall_Select_Track2 0
 KEY 1 51 _Ultraschall_Select_Track3 0
@@ -270,8 +272,8 @@ KEY 1 113 _Ultraschall_Snapshot_2 0
 KEY 1 112 _Ultraschall_Snapshot_1 0
 KEY 1 116 _Ultraschall_Snapshot_Editor 0
 KEY 17 72 _Ultraschall_Toggle_Peak_Gain_Normal_Max 0
-KEY 9 1034 _Ultraschall_Toggle_Follow 0
 KEY 9 70 _Ultraschall_Toggle_Follow 0
+KEY 9 1034 _Ultraschall_Toggle_Follow 0
 KEY 1 66 _Ultraschall_Set_Next_Planned_Marker 0
 KEY 9 89 _Ultraschall_Mute_Selected_Items_In_Time_Range 0
 KEY 13 89 _Ultraschall_Unmute_Selected_Items_In_Time_Range 0
@@ -281,9 +283,9 @@ KEY 1 90 _Ultraschall_Toggle_Arrange_Zoom 0
 KEY 0 43 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
 KEY 13 187 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
 KEY 1 32806 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
+KEY 0 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 9 189 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 1 32808 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
-KEY 0 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 5 65 _Ultraschall_Toggle_All_Track_Recarm_States 0
 KEY 9 84 _Ultraschall_Insert_And_Arm_New_Audio_Track 0
 KEY 9 77 _Ultraschall_Set_Marker_Play 0
@@ -304,4 +306,3 @@ KEY 16 228 _Ultraschall_Zoom_to_Region_at_Edit_Cursor 0
 KEY 1 74 _Ultraschall_Shuttle_Backward 0
 KEY 1 76 _Ultraschall_Shuttle_Forward 0
 KEY 1 75 _Ultraschall_Shuttle_Pause 0
-KEY 21 82 _Ultraschall_RippleInsertRecording 0

--- a/reaper-kb.ini
+++ b/reaper-kb.ini
@@ -123,38 +123,44 @@ SCR 4 0 Ultraschall_Shuttle_Backward "Custom: ULTRASCHALL: Shuttle Backward" ult
 SCR 516 0 Ultraschall_Shuttle_Forward "Custom: ULTRASCHALL: Shuttle Forward" ultraschall_shuttle_forward.lua
 SCR 4 0 Ultraschall_Shuttle_Pause "Custom: ULTRASCHALL: Shuttle Pause" ultraschall_shuttle_pause.lua
 SCR 4 0 Ultraschall_Shuttle_Background_Script "Custom: ULTRASCHALL: Shuttle Background Script" ultraschall_shuttle_background_script.lua
-KEY 25 83 0 0
-KEY 0 123 0 0
-KEY 9 32802 0 0
-KEY 0 61 0 0
-KEY 0 39 0 0
-KEY 5 69 0 0
-KEY 0 34 0 0
-KEY 1 70 0 0
-KEY 8 93 0 0
+SCR 4 0 RSac7acc13ffc36a55de5610546c1e145073ac546a "Custom: ultraschall_Help_Ultraschall_Api_Functions_Reference.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Januar2019-RippleInsertRecording\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Ultraschall_Api_Functions_Reference.lua
+SCR 4 0 RS21fd22dc9bf9a2dd8e3f0f091a6fefe12d2def6b "Custom: ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Januar2019-RippleInsertRecording\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua
+SCR 4 0 RS3ed126b5b32884379d58eea488603b88c85a618e "Custom: ultraschall_Help_Reaper_Api_Documentation.lua" C:\Ultraschall_3.2_Hackverzeichnisse\Ultraschall-Portable_Januar2019-RippleInsertRecording\UserPlugins\ultraschall_api\\Scripts\ultraschall_Help_Reaper_Api_Documentation.lua
+SCR 4 0 Ultraschall_RippleInsertRecording "Custom: ULTRASCHALL: Insert recording at editcursorposition without creating takes(ripple insert recording)" ultraschall_InsertRecording.lua
+SCR 4 0 RS1ee9bb229dabffe151848d7efa3c10f748e1a1cf "Custom: lyrics.lua" Cockos/lyrics.lua
+SCR 4 32060 RS7d3c_1ee9bb229dabffe151848d7efa3c10f748e1a1cf "Custom: lyrics.lua" Cockos/lyrics.lua
+KEY 9 219 0 0
 KEY 5 86 0 0
-KEY 8 91 0 0
-KEY 1 87 0 0
-KEY 25 32806 0 0
-KEY 0 126 0 0
-KEY 0 96 0 0
-KEY 255 218 0 0
-KEY 1 84 0 0
+KEY 1 70 0 0
+KEY 5 69 0 0
 KEY 1 86 0 0
+KEY 9 221 0 0
+KEY 255 218 0 0
+KEY 1 87 0 0
+KEY 9 32814 0 0
+KEY 9 32802 0 0
+KEY 25 32806 0 0
 KEY 25 32808 0 0
 KEY 5 70 0 0
-KEY 9 32814 0 0
 KEY 0 125 0 0
+KEY 0 123 0 0
+KEY 0 34 0 0
+KEY 0 39 0 0
+KEY 1 84 0 0
+KEY 0 126 0 0
+KEY 0 61 0 0
+KEY 0 96 0 0
+KEY 25 83 0 0
 KEY 176 1 26 0
 KEY 176 2 34 0
 KEY 176 3 42 0
 KEY 176 4 50 0
 KEY 255 216 988 0
 KEY 255 248 989 0
-KEY 255 251 990 0
 KEY 176 432 990 0
-KEY 176 182 992 0
+KEY 255 251 990 0
 KEY 176 1080 992 0
+KEY 176 182 992 0
 KEY 176 433 996 0
 KEY 176 1204 998 0
 KEY 255 8650 998 0
@@ -167,10 +173,10 @@ KEY 1 32807 40105 0
 KEY 5 220 40113 0
 KEY 5 84 40142 0
 KEY 0 63 40151 0
-KEY 8 46 40175 0
-KEY 144 16274 40201 0
+KEY 9 190 40175 0
 KEY 17 8 40201 0
-KEY 16 45 40295 0
+KEY 144 16274 40201 0
+KEY 17 189 40295 0
 KEY 17 34 40295 0
 KEY 1 57 40296 0
 KEY 1 48 40297 0
@@ -184,9 +190,9 @@ KEY 1 117 40422 0
 KEY 0 93 40434 0
 KEY 1 1048 40434 0
 KEY 5 121 40477 0
-KEY 16 44 40605 0
-KEY 144 16268 40625 0
+KEY 17 188 40605 0
 KEY 1 73 40625 0
+KEY 144 16268 40625 0
 KEY 1 79 40626 0
 KEY 144 16269 40626 0
 KEY 17 73 40630 0
@@ -197,7 +203,7 @@ KEY 9 76 40687 0
 KEY 1 8 40697 0
 KEY 1 32814 40697 0
 KEY 1 83 40759 0
-KEY 16 46 40867 0
+KEY 17 190 40867 0
 KEY 5 78 40936 0
 KEY 17 32806 41167 0
 KEY 17 32808 41168 0
@@ -226,12 +232,12 @@ KEY 5 8 _Ultraschall_Delete_Last_Marker 0
 KEY 1 77 _Ultraschall_Set_Marker 0
 KEY 144 16256 _Ultraschall_Set_Marker 0
 KEY 5 77 _Ultraschall_Set_NamedMarker 0
-KEY 144 16270 _Ultraschall_Safemode_Start_Stop 0
 KEY 1 13 _Ultraschall_Safemode_Start_Stop 0
 KEY 144 16290 _Ultraschall_Safemode_Start_Stop 0
+KEY 144 16270 _Ultraschall_Safemode_Start_Stop 0
+KEY 1 32 _Ultraschall_Safemode_Start_Pause 0
 KEY 144 16271 _Ultraschall_Safemode_Start_Pause 0
 KEY 144 16291 _Ultraschall_Safemode_Start_Pause 0
-KEY 1 32 _Ultraschall_Safemode_Start_Pause 0
 KEY 1 49 _Ultraschall_Select_Track1 0
 KEY 1 50 _Ultraschall_Select_Track2 0
 KEY 1 51 _Ultraschall_Select_Track3 0
@@ -247,8 +253,8 @@ KEY 1 118 _Ultraschall_Set_View_Setup 0
 KEY 1 119 _Ultraschall_Set_View_Record 0
 KEY 1 121 _Ultraschall_Set_View_Story 0
 KEY 1 120 _Ultraschall_Set_View_Edit 0
-KEY 5 55 _Ultraschall_Toggle_Mouse_Selection 0
 KEY 5 51 _Ultraschall_Toggle_Mouse_Selection 0
+KEY 5 55 _Ultraschall_Toggle_Mouse_Selection 0
 KEY 17 67 _Ultraschall_ColorPicker 0
 KEY 9 75 _Ultraschall_KeyMap 0
 KEY 17 66 _Ultraschall_Open_Project_Folder 0
@@ -264,32 +270,32 @@ KEY 1 113 _Ultraschall_Snapshot_2 0
 KEY 1 112 _Ultraschall_Snapshot_1 0
 KEY 1 116 _Ultraschall_Snapshot_Editor 0
 KEY 17 72 _Ultraschall_Toggle_Peak_Gain_Normal_Max 0
-KEY 9 70 _Ultraschall_Toggle_Follow 0
 KEY 9 1034 _Ultraschall_Toggle_Follow 0
+KEY 9 70 _Ultraschall_Toggle_Follow 0
 KEY 1 66 _Ultraschall_Set_Next_Planned_Marker 0
 KEY 9 89 _Ultraschall_Mute_Selected_Items_In_Time_Range 0
 KEY 13 89 _Ultraschall_Unmute_Selected_Items_In_Time_Range 0
 KEY 5 72 _Ultraschall_Toggle_Envelope_Height 0
 KEY 29 85 _Ultraschall_Mastermind 0
 KEY 1 90 _Ultraschall_Toggle_Arrange_Zoom 0
-KEY 8 43 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
 KEY 0 43 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
+KEY 13 187 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
 KEY 1 32806 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
+KEY 9 189 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 1 32808 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
-KEY 8 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 0 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 5 65 _Ultraschall_Toggle_All_Track_Recarm_States 0
 KEY 9 84 _Ultraschall_Insert_And_Arm_New_Audio_Track 0
 KEY 9 77 _Ultraschall_Set_Marker_Play 0
 KEY 13 77 _Ultraschall_Set_Namedmarker_Play 0
 KEY 9 69 _Ultraschall_Set_Edit_Play 0
-KEY 255 200 _Ultraschall_Zoomlimiter 0
 KEY 255 250 _Ultraschall_Zoomlimiter 0
+KEY 255 200 _Ultraschall_Zoomlimiter 0
 KEY 1 1034 _Ultraschall_Go_To_Cursor 0
 KEY 17 74 _Ultraschall_Toggle_Playrate 0
-KEY 24 45 _Ultraschall_Zoom_Out_Centered_Cursorposition 0
-KEY 17 87 _Ultraschall_Go_To_Start_Of_Project 0
+KEY 25 189 _Ultraschall_Zoom_Out_Centered_Cursorposition 0
 KEY 1 32804 _Ultraschall_Go_To_Start_Of_Project 0
+KEY 17 87 _Ultraschall_Go_To_Start_Of_Project 0
 KEY 1 32803 _Ultraschall_Go_To_End_Of_Project 0
 KEY 9 32807 _Ultraschall_Go_To_Next_Marker_Projectend 0
 KEY 9 32805 _Ultraschall_Go_To_Previous_Marker_Projectstart 0
@@ -298,3 +304,4 @@ KEY 16 228 _Ultraschall_Zoom_to_Region_at_Edit_Cursor 0
 KEY 1 74 _Ultraschall_Shuttle_Backward 0
 KEY 1 76 _Ultraschall_Shuttle_Forward 0
 KEY 1 75 _Ultraschall_Shuttle_Pause 0
+KEY 21 82 _Ultraschall_RippleInsertRecording 0


### PR DESCRIPTION
Ultraschall-Portable_Januar2019-RippleInsertRecording
    Scripts/ultraschall_InsertRecording.lua
    UserPlugins/ultraschall_api/ultraschall_hotfixes.lua
    reaper-kb.ini
        Erlaubt es einem eine Aufnahme einzufügen, ohne dabei zusätzliche Takes zu erstellen.
        Das ist praktisch, wenn man einen Podcast macht und beim Abhören merkt, "Oh, da fehlt aber noch ein Satz".
        Es splittet alle Spuren an der NeuAufnahme-Stelle, verschiebt alles was danach kommt um 4 Sekunden nach hinten und
        startet Aufnahme.
        Wenn die Lücke zu klein würde, verschiebt es alles nach hinten, so dass Items nie überschrieben werden.
        Wenn man die Aufnahme beendet, wird die Lücke wieder geschlossen.

        Auch Marker/Regions und Envelope-punkte werden verschoben(hierzu ist es wichtig die ultraschall_hotfixes.lua reinzunehmen).

        Ich habs testweise gelegt auf die Tastenkombination Alt+Shift+R.