### PR TITLE
Cleanup: ultraschall.ini -> alles in view wurde in ultraschall_gui ve…

### DIFF
--- a/Scripts/ultraschall_toggle_arrange_zoom.lua
+++ b/Scripts/ultraschall_toggle_arrange_zoom.lua
@@ -30,19 +30,19 @@ zoomfactor=reaper.GetHZoomLevel() -- get current zoom-level
 ZoomedInLevelDef=400              -- set this to the "zoom in"-level, you want to have
                                   -- 0.007(max zoom out) to 1000000(max zoom in) is valid, 
                                   -- 400 is recommended
-Zoomstate=ultraschall.GetUSExternalState("view","zoom_toggle_state")
-ZoomedInLevel=ultraschall.GetUSExternalState("view","zoomin_level")
+Zoomstate=ultraschall.GetUSExternalState("ultraschall_gui","zoom_toggle_state")
+ZoomedInLevel=ultraschall.GetUSExternalState("ultraschall_gui","zoomin_level")
 ZoomedInLevel=tonumber(ZoomedInLevel)
 if ZoomedInLevel==-1 or ZoomedInLevel==nil then
   ZoomedInLevel=ZoomedInLevelDef
 end
 
 if Zoomstate=="false" or zoomfactor~=ZoomedInLevel then
-   ultraschall.SetUSExternalState("view","zoom_toggle_state","true",false)
-   ultraschall.SetUSExternalState("view","old_zoomfactor",zoomfactor,false)
+   ultraschall.SetUSExternalState("ultraschall_gui","zoom_toggle_state","true",false)
+   ultraschall.SetUSExternalState("ultraschall_gui","zoomfactor_old",zoomfactor,false)
    reaper.adjustZoom(ZoomedInLevel, 1, true, 0)
 else
-  ultraschall.SetUSExternalState("view","zoom_toggle_state","false",false)
-  oldzoomfactor=ultraschall.GetUSExternalState("view","old_zoomfactor")
+  ultraschall.SetUSExternalState("ultraschall_gui","zoom_toggle_state","false",false)
+  oldzoomfactor=ultraschall.GetUSExternalState("ultraschall_gui","zoomfactor_old")
   reaper.adjustZoom(tonumber(oldzoomfactor), 1, true, 0)
 end

--- a/ultraschall.ini
+++ b/ultraschall.ini
@@ -14,6 +14,9 @@ state=1
 sec=0
 view=setup
 views=55795
+zoom_toggle_state=false
+zoomfactor_old=5.0316460849901
+zoomin_level=400
 
 [ultraschall_mouse]
 state=0
@@ -30,9 +33,4 @@ Safemode_Toggle=OFF
 
 [ultraschall_update]
 update_check=1
-
-[view]
-old_zoomfactor=1.0472219665757
-zoom_toggle_state=true
-zoomin_level=400
 


### PR DESCRIPTION
…rschoben

Cleanup:

Alle Key-Values vom Schnellzoom-Feature(Taste z) wurden von Section view in ultraschall_gui verschoben.