### PR TITLE
Renumeriere ChapterMarker

### DIFF
--- a/Scripts/ultraschall_Renumerate_Chapter_Markers.lua
+++ b/Scripts/ultraschall_Renumerate_Chapter_Markers.lua
@@ -1,0 +1,33 @@
+--[[
+################################################################################
+# 
+# Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# 
+################################################################################
+]]
+
+-- renumerates chapter-markers
+-- leaves planned chapter-markers, regions and editmarkers untouched
+
+dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+
+retval = ultraschall.RenumerateMarkers(0, 1)
+

--- a/Scripts/ultraschall_Renumerate_Chapter_Markers_Backgrounddaemon.lua
+++ b/Scripts/ultraschall_Renumerate_Chapter_Markers_Backgrounddaemon.lua
@@ -1,0 +1,57 @@
+--[[
+################################################################################
+# 
+# Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# 
+################################################################################
+]]
+
+-- renumerates chapter-markers if they change
+-- leaves planned chapter-markers, regions and editmarkers untouched
+
+dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+
+oldmarker_update_counter = ultraschall.GetMarkerUpdateCounter()
+
+
+if reaper.GetExtState("ultraschall", "renumerate_chaptermarkers_bgdaemon")~="" then return end
+
+reaper.SetExtState("ultraschall", "renumerate_chaptermarkers_bgdaemon", "running", false)
+
+
+function exit()
+  reaper.DeleteExtState("ultraschall", "renumerate_chaptermarkers_bgdaemon",false)
+end
+
+reaper.atexit(exit)
+
+function main()
+  marker_update_counter = ultraschall.GetMarkerUpdateCounter()
+  if marker_update_counter~=oldmarker_update_counter then
+    retval = ultraschall.RenumerateMarkers(0, 1)
+  end
+  oldmarker_update_counter = ultraschall.GetMarkerUpdateCounter()
+  ultraschall.Defer1(main,1,15)
+end
+
+main()
+
+

--- a/reaper-kb.ini
+++ b/reaper-kb.ini
@@ -123,40 +123,39 @@ SCR 4 0 Ultraschall_Shuttle_Backward "Custom: ULTRASCHALL: Shuttle Backward" ult
 SCR 516 0 Ultraschall_Shuttle_Forward "Custom: ULTRASCHALL: Shuttle Forward" ultraschall_shuttle_forward.lua
 SCR 4 0 Ultraschall_Shuttle_Pause "Custom: ULTRASCHALL: Shuttle Pause" ultraschall_shuttle_pause.lua
 SCR 4 0 Ultraschall_Shuttle_Background_Script "Custom: ULTRASCHALL: Shuttle Background Script" ultraschall_shuttle_background_script.lua
-SCR 4 0 Ultraschall_Renumerate_Chapter_Markers "Custom: ULTRASCHALL: Renumerate chapter markers" ultraschall_Renumerate_Chapter_Markers.lua
-SCR 516 0 Ultraschall_Renumerate_Chapter_Markers_BGDaemon "Custom: ULTRASCHALL: Renumerate chapter markers - background-daemon" ultraschall_Renumerate_Chapter_Markers_Backgrounddaemon.lua
-SCR 4 0 RS1ee9bb229dabffe151848d7efa3c10f748e1a1cf "Custom: lyrics.lua" Cockos/lyrics.lua
-SCR 4 32060 RS7d3c_1ee9bb229dabffe151848d7efa3c10f748e1a1cf "Custom: lyrics.lua" Cockos/lyrics.lua
-KEY 9 219 0 0
-KEY 5 86 0 0
-KEY 1 70 0 0
-KEY 5 69 0 0
-KEY 1 86 0 0
-KEY 9 221 0 0
-KEY 255 218 0 0
-KEY 1 87 0 0
-KEY 9 32814 0 0
+SCR 4 0 Ultraschall_Ultraschall_Api_Functions_Documentation "Custom: Documentation: Ultraschall-API-Functions-reference" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Ultraschall_Api_Functions_Reference.lua
+SCR 4 0 Ultraschall_Ultraschall_Api_Concepts_Documentation "Custom: Documentation: Ultraschall-API-Concepts-reference" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua
+SCR 4 0 Ultraschall_Reaper_Api_Documentation "Custom: Documentation: Reaper Documentation(Ultraschall version)" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Reaper_Api_Documentation.lua
+KEY 25 83 0 0
+KEY 0 123 0 0
 KEY 9 32802 0 0
+KEY 0 61 0 0
+KEY 0 39 0 0
+KEY 5 69 0 0
+KEY 0 34 0 0
+KEY 1 70 0 0
+KEY 8 93 0 0
+KEY 5 86 0 0
+KEY 8 91 0 0
+KEY 1 87 0 0
 KEY 25 32806 0 0
+KEY 0 126 0 0
+KEY 0 96 0 0
+KEY 255 218 0 0
+KEY 1 84 0 0
+KEY 1 86 0 0
 KEY 25 32808 0 0
 KEY 5 70 0 0
+KEY 9 32814 0 0
 KEY 0 125 0 0
-KEY 0 123 0 0
-KEY 0 34 0 0
-KEY 0 39 0 0
-KEY 1 84 0 0
-KEY 0 126 0 0
-KEY 0 61 0 0
-KEY 0 96 0 0
-KEY 25 83 0 0
 KEY 176 1 26 0
 KEY 176 2 34 0
 KEY 176 3 42 0
 KEY 176 4 50 0
 KEY 255 216 988 0
 KEY 255 248 989 0
-KEY 176 432 990 0
 KEY 255 251 990 0
+KEY 176 432 990 0
 KEY 176 182 992 0
 KEY 176 1080 992 0
 KEY 176 433 996 0
@@ -171,10 +170,10 @@ KEY 1 32807 40105 0
 KEY 5 220 40113 0
 KEY 5 84 40142 0
 KEY 0 63 40151 0
-KEY 9 190 40175 0
+KEY 8 46 40175 0
 KEY 144 16274 40201 0
 KEY 17 8 40201 0
-KEY 17 189 40295 0
+KEY 16 45 40295 0
 KEY 17 34 40295 0
 KEY 1 57 40296 0
 KEY 1 48 40297 0
@@ -188,7 +187,7 @@ KEY 1 117 40422 0
 KEY 0 93 40434 0
 KEY 1 1048 40434 0
 KEY 5 121 40477 0
-KEY 17 188 40605 0
+KEY 16 44 40605 0
 KEY 144 16268 40625 0
 KEY 1 73 40625 0
 KEY 1 79 40626 0
@@ -198,10 +197,10 @@ KEY 17 79 40631 0
 KEY 17 70 40638 0
 KEY 17 76 40651 0
 KEY 9 76 40687 0
-KEY 1 32814 40697 0
 KEY 1 8 40697 0
+KEY 1 32814 40697 0
 KEY 1 83 40759 0
-KEY 17 190 40867 0
+KEY 16 46 40867 0
 KEY 5 78 40936 0
 KEY 17 32806 41167 0
 KEY 17 32808 41168 0
@@ -211,8 +210,8 @@ KEY 17 32805 41250 0
 KEY 9 49 41357 0
 KEY 21 72 42307 0
 KEY 1 65 _Ultraschall_Play_From_Editcursor_Position 0
-KEY 9 32801 _Ultraschall_ZoomToSelection 0
 KEY 0 228 _Ultraschall_ZoomToSelection 0
+KEY 9 32801 _Ultraschall_ZoomToSelection 0
 KEY 25 82 _Ultraschall_ResetPlaybackRate_and_RenderProject 0
 KEY 17 83 _Ultraschall_Slice_and_AddMetadata 0
 KEY 17 80 _Ultraschall_SkipLoopPlayback 0
@@ -221,21 +220,21 @@ KEY 1 80 _Ultraschall_SkipLoopPlayback_Absolute 0
 KEY 5 73 _Ultraschall_PlayFromInpoint 0
 KEY 5 79 _Ultraschall_PlayFromOutpoint 0
 KEY 1 107 _Ultraschall_Zoom_In_Horizontal 0
-KEY 1 109 _Ultraschall_Zoom_Out_Horizontal 0
 KEY 0 91 _Ultraschall_Zoom_Out_Horizontal 0
+KEY 1 109 _Ultraschall_Zoom_Out_Horizontal 0
 KEY 144 16258 _Ultraschall_Set_Edit 0
 KEY 1 69 _Ultraschall_Set_Edit 0
 KEY 17 77 _Ultraschall_Insert_Chapter_Marker_Back_In_Time 0
 KEY 5 8 _Ultraschall_Delete_Last_Marker 0
-KEY 144 16256 _Ultraschall_Set_Marker 0
 KEY 1 77 _Ultraschall_Set_Marker 0
+KEY 144 16256 _Ultraschall_Set_Marker 0
 KEY 5 77 _Ultraschall_Set_NamedMarker 0
 KEY 144 16270 _Ultraschall_Safemode_Start_Stop 0
 KEY 1 13 _Ultraschall_Safemode_Start_Stop 0
 KEY 144 16290 _Ultraschall_Safemode_Start_Stop 0
-KEY 1 32 _Ultraschall_Safemode_Start_Pause 0
 KEY 144 16271 _Ultraschall_Safemode_Start_Pause 0
 KEY 144 16291 _Ultraschall_Safemode_Start_Pause 0
+KEY 1 32 _Ultraschall_Safemode_Start_Pause 0
 KEY 1 49 _Ultraschall_Select_Track1 0
 KEY 1 50 _Ultraschall_Select_Track2 0
 KEY 1 51 _Ultraschall_Select_Track3 0
@@ -251,8 +250,8 @@ KEY 1 118 _Ultraschall_Set_View_Setup 0
 KEY 1 119 _Ultraschall_Set_View_Record 0
 KEY 1 121 _Ultraschall_Set_View_Story 0
 KEY 1 120 _Ultraschall_Set_View_Edit 0
-KEY 5 51 _Ultraschall_Toggle_Mouse_Selection 0
 KEY 5 55 _Ultraschall_Toggle_Mouse_Selection 0
+KEY 5 51 _Ultraschall_Toggle_Mouse_Selection 0
 KEY 17 67 _Ultraschall_ColorPicker 0
 KEY 9 75 _Ultraschall_KeyMap 0
 KEY 17 66 _Ultraschall_Open_Project_Folder 0
@@ -276,24 +275,24 @@ KEY 13 89 _Ultraschall_Unmute_Selected_Items_In_Time_Range 0
 KEY 5 72 _Ultraschall_Toggle_Envelope_Height 0
 KEY 29 85 _Ultraschall_Mastermind 0
 KEY 1 90 _Ultraschall_Toggle_Arrange_Zoom 0
+KEY 8 43 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
 KEY 0 43 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
-KEY 13 187 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
 KEY 1 32806 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
-KEY 0 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
-KEY 9 189 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 1 32808 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
+KEY 8 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
+KEY 0 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 5 65 _Ultraschall_Toggle_All_Track_Recarm_States 0
 KEY 9 84 _Ultraschall_Insert_And_Arm_New_Audio_Track 0
 KEY 9 77 _Ultraschall_Set_Marker_Play 0
 KEY 13 77 _Ultraschall_Set_Namedmarker_Play 0
 KEY 9 69 _Ultraschall_Set_Edit_Play 0
-KEY 255 250 _Ultraschall_Zoomlimiter 0
 KEY 255 200 _Ultraschall_Zoomlimiter 0
+KEY 255 250 _Ultraschall_Zoomlimiter 0
 KEY 1 1034 _Ultraschall_Go_To_Cursor 0
 KEY 17 74 _Ultraschall_Toggle_Playrate 0
-KEY 25 189 _Ultraschall_Zoom_Out_Centered_Cursorposition 0
-KEY 1 32804 _Ultraschall_Go_To_Start_Of_Project 0
+KEY 24 45 _Ultraschall_Zoom_Out_Centered_Cursorposition 0
 KEY 17 87 _Ultraschall_Go_To_Start_Of_Project 0
+KEY 1 32804 _Ultraschall_Go_To_Start_Of_Project 0
 KEY 1 32803 _Ultraschall_Go_To_End_Of_Project 0
 KEY 9 32807 _Ultraschall_Go_To_Next_Marker_Projectend 0
 KEY 9 32805 _Ultraschall_Go_To_Previous_Marker_Projectstart 0

--- a/reaper-kb.ini
+++ b/reaper-kb.ini
@@ -123,39 +123,40 @@ SCR 4 0 Ultraschall_Shuttle_Backward "Custom: ULTRASCHALL: Shuttle Backward" ult
 SCR 516 0 Ultraschall_Shuttle_Forward "Custom: ULTRASCHALL: Shuttle Forward" ultraschall_shuttle_forward.lua
 SCR 4 0 Ultraschall_Shuttle_Pause "Custom: ULTRASCHALL: Shuttle Pause" ultraschall_shuttle_pause.lua
 SCR 4 0 Ultraschall_Shuttle_Background_Script "Custom: ULTRASCHALL: Shuttle Background Script" ultraschall_shuttle_background_script.lua
-SCR 4 0 Ultraschall_Ultraschall_Api_Functions_Documentation "Custom: Documentation: Ultraschall-API-Functions-reference" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Ultraschall_Api_Functions_Reference.lua
-SCR 4 0 Ultraschall_Ultraschall_Api_Concepts_Documentation "Custom: Documentation: Ultraschall-API-Concepts-reference" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Ultraschall_Api_Introduction_and_Concepts.lua
-SCR 4 0 Ultraschall_Reaper_Api_Documentation "Custom: Documentation: Reaper Documentation(Ultraschall version)" ../UserPlugins/ultraschall_api/Scripts/ultraschall_Help_Reaper_Api_Documentation.lua
-KEY 25 83 0 0
-KEY 0 123 0 0
-KEY 9 32802 0 0
-KEY 0 61 0 0
-KEY 0 39 0 0
-KEY 5 69 0 0
-KEY 0 34 0 0
-KEY 1 70 0 0
-KEY 8 93 0 0
+SCR 4 0 Ultraschall_Renumerate_Chapter_Markers "Custom: ULTRASCHALL: Renumerate chapter markers" ultraschall_Renumerate_Chapter_Markers.lua
+SCR 516 0 Ultraschall_Renumerate_Chapter_Markers_BGDaemon "Custom: ULTRASCHALL: Renumerate chapter markers - background-daemon" ultraschall_Renumerate_Chapter_Markers_Backgrounddaemon.lua
+SCR 4 0 RS1ee9bb229dabffe151848d7efa3c10f748e1a1cf "Custom: lyrics.lua" Cockos/lyrics.lua
+SCR 4 32060 RS7d3c_1ee9bb229dabffe151848d7efa3c10f748e1a1cf "Custom: lyrics.lua" Cockos/lyrics.lua
+KEY 9 219 0 0
 KEY 5 86 0 0
-KEY 8 91 0 0
-KEY 1 87 0 0
-KEY 25 32806 0 0
-KEY 0 126 0 0
-KEY 0 96 0 0
-KEY 255 218 0 0
-KEY 1 84 0 0
+KEY 1 70 0 0
+KEY 5 69 0 0
 KEY 1 86 0 0
+KEY 9 221 0 0
+KEY 255 218 0 0
+KEY 1 87 0 0
+KEY 9 32814 0 0
+KEY 9 32802 0 0
+KEY 25 32806 0 0
 KEY 25 32808 0 0
 KEY 5 70 0 0
-KEY 9 32814 0 0
 KEY 0 125 0 0
+KEY 0 123 0 0
+KEY 0 34 0 0
+KEY 0 39 0 0
+KEY 1 84 0 0
+KEY 0 126 0 0
+KEY 0 61 0 0
+KEY 0 96 0 0
+KEY 25 83 0 0
 KEY 176 1 26 0
 KEY 176 2 34 0
 KEY 176 3 42 0
 KEY 176 4 50 0
 KEY 255 216 988 0
 KEY 255 248 989 0
-KEY 255 251 990 0
 KEY 176 432 990 0
+KEY 255 251 990 0
 KEY 176 182 992 0
 KEY 176 1080 992 0
 KEY 176 433 996 0
@@ -170,10 +171,10 @@ KEY 1 32807 40105 0
 KEY 5 220 40113 0
 KEY 5 84 40142 0
 KEY 0 63 40151 0
-KEY 8 46 40175 0
+KEY 9 190 40175 0
 KEY 144 16274 40201 0
 KEY 17 8 40201 0
-KEY 16 45 40295 0
+KEY 17 189 40295 0
 KEY 17 34 40295 0
 KEY 1 57 40296 0
 KEY 1 48 40297 0
@@ -187,7 +188,7 @@ KEY 1 117 40422 0
 KEY 0 93 40434 0
 KEY 1 1048 40434 0
 KEY 5 121 40477 0
-KEY 16 44 40605 0
+KEY 17 188 40605 0
 KEY 144 16268 40625 0
 KEY 1 73 40625 0
 KEY 1 79 40626 0
@@ -197,10 +198,10 @@ KEY 17 79 40631 0
 KEY 17 70 40638 0
 KEY 17 76 40651 0
 KEY 9 76 40687 0
-KEY 1 8 40697 0
 KEY 1 32814 40697 0
+KEY 1 8 40697 0
 KEY 1 83 40759 0
-KEY 16 46 40867 0
+KEY 17 190 40867 0
 KEY 5 78 40936 0
 KEY 17 32806 41167 0
 KEY 17 32808 41168 0
@@ -210,8 +211,8 @@ KEY 17 32805 41250 0
 KEY 9 49 41357 0
 KEY 21 72 42307 0
 KEY 1 65 _Ultraschall_Play_From_Editcursor_Position 0
-KEY 0 228 _Ultraschall_ZoomToSelection 0
 KEY 9 32801 _Ultraschall_ZoomToSelection 0
+KEY 0 228 _Ultraschall_ZoomToSelection 0
 KEY 25 82 _Ultraschall_ResetPlaybackRate_and_RenderProject 0
 KEY 17 83 _Ultraschall_Slice_and_AddMetadata 0
 KEY 17 80 _Ultraschall_SkipLoopPlayback 0
@@ -220,21 +221,21 @@ KEY 1 80 _Ultraschall_SkipLoopPlayback_Absolute 0
 KEY 5 73 _Ultraschall_PlayFromInpoint 0
 KEY 5 79 _Ultraschall_PlayFromOutpoint 0
 KEY 1 107 _Ultraschall_Zoom_In_Horizontal 0
-KEY 0 91 _Ultraschall_Zoom_Out_Horizontal 0
 KEY 1 109 _Ultraschall_Zoom_Out_Horizontal 0
+KEY 0 91 _Ultraschall_Zoom_Out_Horizontal 0
 KEY 144 16258 _Ultraschall_Set_Edit 0
 KEY 1 69 _Ultraschall_Set_Edit 0
 KEY 17 77 _Ultraschall_Insert_Chapter_Marker_Back_In_Time 0
 KEY 5 8 _Ultraschall_Delete_Last_Marker 0
-KEY 1 77 _Ultraschall_Set_Marker 0
 KEY 144 16256 _Ultraschall_Set_Marker 0
+KEY 1 77 _Ultraschall_Set_Marker 0
 KEY 5 77 _Ultraschall_Set_NamedMarker 0
 KEY 144 16270 _Ultraschall_Safemode_Start_Stop 0
 KEY 1 13 _Ultraschall_Safemode_Start_Stop 0
 KEY 144 16290 _Ultraschall_Safemode_Start_Stop 0
+KEY 1 32 _Ultraschall_Safemode_Start_Pause 0
 KEY 144 16271 _Ultraschall_Safemode_Start_Pause 0
 KEY 144 16291 _Ultraschall_Safemode_Start_Pause 0
-KEY 1 32 _Ultraschall_Safemode_Start_Pause 0
 KEY 1 49 _Ultraschall_Select_Track1 0
 KEY 1 50 _Ultraschall_Select_Track2 0
 KEY 1 51 _Ultraschall_Select_Track3 0
@@ -250,8 +251,8 @@ KEY 1 118 _Ultraschall_Set_View_Setup 0
 KEY 1 119 _Ultraschall_Set_View_Record 0
 KEY 1 121 _Ultraschall_Set_View_Story 0
 KEY 1 120 _Ultraschall_Set_View_Edit 0
-KEY 5 55 _Ultraschall_Toggle_Mouse_Selection 0
 KEY 5 51 _Ultraschall_Toggle_Mouse_Selection 0
+KEY 5 55 _Ultraschall_Toggle_Mouse_Selection 0
 KEY 17 67 _Ultraschall_ColorPicker 0
 KEY 9 75 _Ultraschall_KeyMap 0
 KEY 17 66 _Ultraschall_Open_Project_Folder 0
@@ -275,24 +276,24 @@ KEY 13 89 _Ultraschall_Unmute_Selected_Items_In_Time_Range 0
 KEY 5 72 _Ultraschall_Toggle_Envelope_Height 0
 KEY 29 85 _Ultraschall_Mastermind 0
 KEY 1 90 _Ultraschall_Toggle_Arrange_Zoom 0
-KEY 8 43 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
 KEY 0 43 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
+KEY 13 187 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
 KEY 1 32806 _Ultraschall_ZoomIn_Center_To_Cursorposition 0
-KEY 1 32808 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
-KEY 8 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 0 45 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
+KEY 9 189 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
+KEY 1 32808 _Ultraschall_ZoomOut_Center_To_Cursorposition 0
 KEY 5 65 _Ultraschall_Toggle_All_Track_Recarm_States 0
 KEY 9 84 _Ultraschall_Insert_And_Arm_New_Audio_Track 0
 KEY 9 77 _Ultraschall_Set_Marker_Play 0
 KEY 13 77 _Ultraschall_Set_Namedmarker_Play 0
 KEY 9 69 _Ultraschall_Set_Edit_Play 0
-KEY 255 200 _Ultraschall_Zoomlimiter 0
 KEY 255 250 _Ultraschall_Zoomlimiter 0
+KEY 255 200 _Ultraschall_Zoomlimiter 0
 KEY 1 1034 _Ultraschall_Go_To_Cursor 0
 KEY 17 74 _Ultraschall_Toggle_Playrate 0
-KEY 24 45 _Ultraschall_Zoom_Out_Centered_Cursorposition 0
-KEY 17 87 _Ultraschall_Go_To_Start_Of_Project 0
+KEY 25 189 _Ultraschall_Zoom_Out_Centered_Cursorposition 0
 KEY 1 32804 _Ultraschall_Go_To_Start_Of_Project 0
+KEY 17 87 _Ultraschall_Go_To_Start_Of_Project 0
 KEY 1 32803 _Ultraschall_Go_To_End_Of_Project 0
 KEY 9 32807 _Ultraschall_Go_To_Next_Marker_Projectend 0
 KEY 9 32805 _Ultraschall_Go_To_Previous_Marker_Projectstart 0


### PR DESCRIPTION
Zwei Actions: eine, die die Chaptermarker bei Bedarf durchnummeriert und ein Background-Daemon, der die Numerierung ca jede halbe Sekunde macht.

Editmarker werden dabei nicht neu durchnummeriert.

Wir müssen mal schaun, was von Beidem mehr Sinn macht, ob dauerhaft im Hintergrund neu zu nummerieren oder nur bei Bedarf.