### PR TITLE
#116 beim eingeben von metadaten sollte man auch kommas eingeben können 

### DIFF
--- a/Scripts/ultraschall_edit_id3_tags.lua
+++ b/Scripts/ultraschall_edit_id3_tags.lua
@@ -27,7 +27,17 @@
 oldnotes=reaper.GetSetProjectNotes(0, false, "")
 oldnotes=string.gsub(oldnotes, "\n", "\b")
 
-retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 5, "Episode Title:,Author:,Podcast:,Podcast Category:,Description:,extrawidth=300, separator=\b", oldnotes)
+if oldnotes=="" then 
+  Date = os.date("*t")
+  oldnotes="\b\b\b"..Date.year
+end
+
+
+--if olll==nil then return end 
+
+retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 6, "Episode Title:,Author:,Podcast:,Year:,Podcast Category:,Description:,extrawidth=300, separator=\b", oldnotes)
+
+
 
 result=string.gsub(result, "\b", "\n")
 

--- a/Scripts/ultraschall_edit_id3_tags.lua
+++ b/Scripts/ultraschall_edit_id3_tags.lua
@@ -24,23 +24,14 @@
 ################################################################################
 ]]
 
+oldnotes=reaper.GetSetProjectNotes(0, false, "")
+oldnotes=string.gsub(oldnotes, "\n", "\b")
 
---retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 6, "Title:,Artist:,Podcast:,Year:,Genre:,Comment:,extrawidth=300, separator=\b", reaper.GetSetProjectNotes(0, false, ""))
+retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 6, "Title:,Artist:,Podcast:,Year:,Genre:,Comment:,extrawidth=300, separator=\b", oldnotes)
 
-dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+result=string.gsub(result, "\b", "\n")
 
--- get current notes and split them at linefeed
-Acount, split_string = ultraschall.SplitStringAtLineFeedToArray(reaper.GetSetProjectNotes(0, false, ""))
-
--- Get Userinputs for metadata
-retval, number_of_inputfields, returnvalues = ultraschall.GetUserInputs("Edit ID3 Podcast Metadata", {"Title:", "Artist:", "Podcast:", "Year:", "Genre:", "Comment:"}, split_string, 300)
-
--- if user has entered values and hit OK, put them into Project Notes
-if retval==true then
-  result=""
-  for i=1, number_of_inputfields do
-    result=result..returnvalues[i].."\n"
-  end
-  notes = reaper.GetSetProjectNotes(0, true, result:sub(1,-2)) -- write new notes
+if retval == true then  
+  notes = reaper.GetSetProjectNotes(0, true, result) -- write new notes
 end
 

--- a/Scripts/ultraschall_edit_id3_tags.lua
+++ b/Scripts/ultraschall_edit_id3_tags.lua
@@ -1,18 +1,18 @@
 --[[
 ################################################################################
-# 
+#
 # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,18 +20,17 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-# 
+#
 ################################################################################
 ]]
 
 oldnotes=reaper.GetSetProjectNotes(0, false, "")
 oldnotes=string.gsub(oldnotes, "\n", "\b")
 
-retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 6, "Title:,Artist:,Podcast:,Year:,Genre:,Comment:,extrawidth=300, separator=\b", oldnotes)
+retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 5, "Episode Title:,Author:,Podcast:,Podcast Category:,Description:,extrawidth=300, separator=\b", oldnotes)
 
 result=string.gsub(result, "\b", "\n")
 
-if retval == true then  
+if retval == true then
   notes = reaper.GetSetProjectNotes(0, true, result) -- write new notes
 end
-

--- a/Scripts/ultraschall_edit_id3_tags.lua
+++ b/Scripts/ultraschall_edit_id3_tags.lua
@@ -1,7 +1,7 @@
 --[[
 ################################################################################
 # 
-# Copyright (c) 2014-2017 Ultraschall (http://ultraschall.fm)
+# Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,158 +24,11 @@
 ################################################################################
 ]]
 
+reaper.MB(reaper.GetSetProjectNotes(0, false, ""),"",0)
 
--- Print Message to console (debugging)
-function Msg(val)
-  reaper.ShowConsoleMsg(tostring(val).."\n")
+retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 6, "Title:,Artist:,Podcast:,Year:,Genre:,Comment:,extrawidth=100, separator=\n", reaper.GetSetProjectNotes(0, false, ""))
+
+if retval == true then  
+  notes = reaper.GetSetProjectNotes(0, true, result) -- write new notes
 end
 
--- Used to escape "'s by toCSV
---function escapeCSV (s)
---  _, count = string.gsub(s, "\"", "\"")
---  if count==nil then count=0 end
---  if math.fmod(count,2)==1 then --if we have a odd number of " replace them with "" 
---    if string.find(s, '["]') then
---      s = '"' .. string.gsub(s, '"', '""') .. '"'
---    end
---  elseif string.find(s,",")~=nil then
---    s="\""..s.."\""
---  end
---  return s
---end
-
-function notes2csv ()
-  local csv = ""
-  local array = {}
-  local count=0
-  notes = reaper.GetSetProjectNotes(0, false, "")
-    for line in notes:gmatch"[^\n]*" do
-    count=count+1
-      csv = csv .. "," .. line --escapeCSV(line)
-      array[count]=line
-    end
-    
-    retval= string.sub(csv, 2) -- remove first ","
-    
-  return retval, count, array
-end
-
-
-
-function csv2lines (line)
-    title = line:match("(.-),")
-    artist= line:match(".-,(.-),")
-    album = line:match(".-,.-,(.-),")
-    year  = line:match(".-,.-,.-,(.-),")
-    genre =   line:match(".-,.-,.-,.-,(.-),")
-    comment = line:match(".-,.-,.-,.-,.-,(.*)")
---[[  pos=0
-  pos_old=1
-  clean=""
-  for i=1, 5,1 do
-    pos=string.find(result,",",pos_old)
-    substring=string.sub(line,pos_old,pos-1)
-    clean=clean..substring.."\n"
-    pos_old=pos+1
-  end
-  --check field 6
-  substring=string.sub(line,pos_old)
-  clean=clean..substring
-  ]]
-  return title.."\n"..artist.."\n"..album.."\n"..year.."\n"..genre.."\n"..comment
-end
-
-function checkevencharacters(string,character)
-  local count=0
-  local even=true
-  for i=1, string.len(string) do
-    if string:sub(i,i)==character then       
-      if even==true then even=false
-      else even=true
-      end
-    end
-  end
-  return even
-end
-
---reaper.ShowConsoleMsg("") --clear console
-dialog_ret_vals, count, dialog_retvals_array = notes2csv() --default values
-
-retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 6, "Title (no comma allowed):,Artist (no comma allowed):,Podcast (no comma allowed):,Year (no comma allowed):,Genre (no comma allowed):,Comment:", dialog_ret_vals)
-
-count=0
-temp=-1
-old_pos=0
-pos=0
-if retval == true then
-  pos=result:match(".-,.-,.-,.-,.-,()")
-  firstvals=result:sub(1,pos-1)
-  restvals=result:sub(pos,-1)
-  pos=restvals:match(".-,()")
-  if pos~=nil then restvals="\""..restvals.."\"" end
-  if restvals:match("\"\".*\"\"")~=nil then restvals=restvals:sub(2,-2) end
-  
-  
-  even=checkevencharacters(firstvals:match(".-,"),"\"")
-  if even==false then firstvals=firstvals:match("(.-),").."\""..firstvals:match(".-(,.*)") end
-
-  even=checkevencharacters(firstvals:match(".-,(.-,)"),"\"")
-  if even==false then firstvals=firstvals:match("(.-,.-),").."\""..firstvals:match(".-,.-(,.*)") end
-
-  even=checkevencharacters(firstvals:match(".-,.-,(.-,)"),"\"")
-  if even==false then firstvals=firstvals:match("(.-,.-,.-),").."\""..firstvals:match(".-,.-,.-(,.*)") end
-
-  even=checkevencharacters(firstvals:match(".-,.-,.-,(.-,)"),"\"")
-  if even==false then firstvals=firstvals:match("(.-,.-,.-,.-),").."\""..firstvals:match(".-,.-,.-,.-(,.*)") end
-  
-  even=checkevencharacters(firstvals:match(".-,.-,.-,.-,(.-,)"),"\"")
-  if even==false then firstvals=firstvals:match("(.-,.-,.-,.-,.-),").."\""..firstvals:match(".-,.-,.-,.-,.-(,.*)") end
-  
-  even=checkevencharacters(restvals,"\"")
-  if even==false then restvals=restvals.."\"" end
-  
-  notes = reaper.GetSetProjectNotes(0, true, csv2lines(firstvals..restvals)) -- write new notes  
-end
-
---[[
-if retval == true then
-  --step through field 1-5 and check if the numer of " is even. Add a " to the end if needed.
-  pos=0
-  pos_old=1
-  clean=""
-  for i=1, 5,1 do
-    pos=string.find(result,",",pos_old)
-    substring=string.sub(result,pos_old,pos-1)
-    _, count = string.gsub(substring, "\"", "\"")
-    if math.fmod(count,2)==1 then substring=substring.."\"" end
-    clean=clean..substring..","
-    pos_old=pos+1
-  end
-  --check field 6
-  substring=string.sub(result,pos_old)
-  _, count = string.gsub(substring, "\"", "\"")
-  if math.fmod(count,2)==1 then substring=substring.."\"" end
-  clean=clean..substring
-  result=clean
-  
-  -- if more than  "," 5 then escape the comment field (surround with ")
-  _, count = string.gsub(result, ",", ",")
-  if count>5 then 
-    pos=0
-    for i=1, 5,1 do
-      pos=string.find(result,",",pos+1)
-    end
-    temp=string.sub(result,pos+1,-1)
-    if temp:match("\"\".*\"\"")~=nil then newresult=string.sub(result,1,pos)..temp:sub(2,-2)
-    else newresult=string.sub(result,1,pos)..string.sub(result,pos+1)
-    end
-    reaper.MB(newresult,result,0)
-    result=newresult
-    --reaper.MB(string.sub(result,pos+1,-1),"",0)
-  end
-
-
-
-  notes = reaper.GetSetProjectNotes(0, true, csv2lines(result)) -- write new notes
-end
---]]

--- a/Scripts/ultraschall_edit_id3_tags.lua
+++ b/Scripts/ultraschall_edit_id3_tags.lua
@@ -24,9 +24,7 @@
 ################################################################################
 ]]
 
-reaper.MB(reaper.GetSetProjectNotes(0, false, ""),"",0)
-
-retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 6, "Title:,Artist:,Podcast:,Year:,Genre:,Comment:,extrawidth=100, separator=\n", reaper.GetSetProjectNotes(0, false, ""))
+retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 6, "Title:,Artist:,Podcast:,Year:,Genre:,Comment:,extrawidth=300, separator=\n", reaper.GetSetProjectNotes(0, false, ""))
 
 if retval == true then  
   notes = reaper.GetSetProjectNotes(0, true, result) -- write new notes

--- a/Scripts/ultraschall_edit_id3_tags.lua
+++ b/Scripts/ultraschall_edit_id3_tags.lua
@@ -24,9 +24,23 @@
 ################################################################################
 ]]
 
-retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 6, "Title:,Artist:,Podcast:,Year:,Genre:,Comment:,extrawidth=300, separator=\n", reaper.GetSetProjectNotes(0, false, ""))
 
-if retval == true then  
-  notes = reaper.GetSetProjectNotes(0, true, result) -- write new notes
+--retval, result = reaper.GetUserInputs("Edit ID3 Podcast Metadata", 6, "Title:,Artist:,Podcast:,Year:,Genre:,Comment:,extrawidth=300, separator=\b", reaper.GetSetProjectNotes(0, false, ""))
+
+dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+
+-- get current notes and split them at linefeed
+Acount, split_string = ultraschall.SplitStringAtLineFeedToArray(reaper.GetSetProjectNotes(0, false, ""))
+
+-- Get Userinputs for metadata
+retval, number_of_inputfields, returnvalues = ultraschall.GetUserInputs("Edit ID3 Podcast Metadata", {"Title:", "Artist:", "Podcast:", "Year:", "Genre:", "Comment:"}, split_string, 300)
+
+-- if user has entered values and hit OK, put them into Project Notes
+if retval==true then
+  result=""
+  for i=1, number_of_inputfields do
+    result=result..returnvalues[i].."\n"
+  end
+  notes = reaper.GetSetProjectNotes(0, true, result:sub(1,-2)) -- write new notes
 end
 


### PR DESCRIPTION
Metadateneingabe erlaubt nun auch Kommas.
Eingabefeld ist länger.

Benötigt Reaper 5.979.