### PR TITLE
Create ultraschall_open_takesourcefile_in_explorer.lua

### DIFF
--- a/Scripts/ultraschall_open_takesourcefile_in_explorer.lua
+++ b/Scripts/ultraschall_open_takesourcefile_in_explorer.lua
@@ -1,0 +1,38 @@
+--[[
+################################################################################
+# 
+# Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# 
+################################################################################
+]]
+
+-- Shows the first selected item in Explorer/Finder
+
+--x,y=reaper.GetMousePosition()
+--MediaItem, MediaItem_Take = reaper.GetItemFromPoint(x,y, true)
+if MediaItem_Take==nil or reaper.IsMediaItemSelected(MediaItem)~=true then  
+  MediaItem = reaper.GetSelectedMediaItem(0,0)
+  MediaItem_Take = reaper.GetActiveTake(MediaItem)
+end
+if MediaItem_Take==nil then reaper.MB("No Item selected", "Error", 0) return end
+PCM_source=reaper.GetMediaItemTake_Source(MediaItem_Take)
+filenamebuf = reaper.GetMediaSourceFileName(PCM_source, "")
+reaper.CF_LocateInExplorer(filenamebuf)

--- a/reaper-kb.ini
+++ b/reaper-kb.ini
@@ -135,6 +135,7 @@ SCR 4 0 Ultraschall_OpenFolder_Api_ExampleScripts "Custom: ULTRASCHALL: Open Ult
 SCR 4 0 ultraschall_Remove_ExampleScripts_From_Reaper "Custom: ULTRASCHALL: Remove Ultraschall-API examplescripts from Reaper" ultraschall_Remove_ExampleScripts_From_Reaper.lua
 SCR 4 0 Ultraschall_Jump_Right_To_Next_Itemedge "Custom: ultraschall_jump_right_to_next_itemedge.lua" ultraschall_jump_right_to_next_itemedge.lua
 SCR 4 0 Ultraschall_Jump_Left_To_Next_Itemedge "Custom: ultraschall_jump_left_to_next_itemedge.lua" ultraschall_jump_left_to_next_itemedge.lua
+SCR 4 0 Ultraschall_Open_TakeSourceFile_In_Finder_Explorer "Custom: ULTRASCHALL: Open take in explorer/finder" ultraschall_open_takesourcefile_in_explorer.lua
 KEY 25 83 0 0
 KEY 0 123 0 0
 KEY 9 32802 0 0


### PR DESCRIPTION
Zeigt das Audiofile des ausgewählten Items im Explorer/Finder an.

Löst #42

Die kb.ini braucht noch foldenen Eintrag.
SCR 4 0 Ultraschall_Open_TakeSourceFile_In_Finder_Explorer "Custom: ULTRASCHALL: Open take in explorer/finder" ultraschall_open_takesourcefile_in_explorer.lua