### PR TITLE
Löst: Ripple Cut bricht ab, wenn es keine Mute-Punkte gibt in der Zeitselektion #143Update ultraschall_ripple_cut.lua

### DIFF
--- a/Scripts/ultraschall_ripple_cut.lua
+++ b/Scripts/ultraschall_ripple_cut.lua
@@ -50,7 +50,7 @@ function AddMuteEnvelopePoint_IfNecessary(startsel, endsel)
     
     if retval==false and Envelope~=nil then
       envIDX, envVal, envPosition = ultraschall.GetPreviousMuteState(i, endsel)
-      reaper.InsertEnvelopePoint(Envelope, endsel, envVal, 1, 0, false, false)
+      if envIDX~=-1 then reaper.InsertEnvelopePoint(Envelope, endsel, envVal, 1, 0, false, false) end
     end
   end
 end


### PR DESCRIPTION
Fixt #143 Ripple Cut bricht ab, wenn es keine Mute-Punkte gibt in der Zeitselektion.

MutePunkte werden nun gecheckt: wenn es keine gibt,  wird keine der MuteSpuren angefasst.

