### PR TITLE
Soundboard Actions, derer viele von.

### DIFF
--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_01.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_01.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #1. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=48  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_02.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_02.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #2. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=49  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_03.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_03.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #3. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=50  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_04.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_04.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #4. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=51  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_05.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_05.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #5. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=52  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_06.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_06.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #6. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=53  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_07.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_07.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #7. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=54  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_08.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_08.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #8. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=55  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_09.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_09.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #9. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=56  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_10.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_10.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #10. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=57  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_11.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_11.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #11. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=58  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_12.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_12.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #12. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=59  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_13.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_13.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #13. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=60  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_14.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_14.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #14. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=61  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_15.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_15.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #15. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=62  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_16.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_16.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #16. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=63  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_17.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_17.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #17. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=64  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_18.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_18.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #18. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=65  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_19.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_19.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #19. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=66  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_20.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_20.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #20. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=67  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_21.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_21.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #21. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=68  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_22.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_22.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #22. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=69  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_23.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_23.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #23. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=70  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_24.lua
+++ b/Scripts/ultraschall_soundboard_play_fadeout-pause_player-nr_24.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and fadeout-pause of Soundboard-player #24. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=71  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_01.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_01.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #1. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=24  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_02.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_02.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #2. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=25  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_03.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_03.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #3. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=26  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_04.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_04.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #4. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=27  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_05.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_05.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #5. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=28  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_06.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_06.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #6. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=29  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_07.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_07.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #7. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=30  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_08.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_08.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #8. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=31  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_09.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_09.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #9. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=32  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_10.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_10.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #10. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=33  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_11.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_11.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #11. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=34  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_12.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_12.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #12. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=35  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_13.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_13.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #13. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=36  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_14.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_14.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #14. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=37  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_15.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_15.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #15. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=38  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_16.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_16.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #16. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=39  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_17.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_17.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #17. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=40  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_18.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_18.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #18. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=41  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_19.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_19.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #19. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=42  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_20.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_20.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #20. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=43  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_21.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_21.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #21. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=44  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_22.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_22.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #22. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=45  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_23.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_23.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #23. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=46  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_pause_player-nr_24.lua
+++ b/Scripts/ultraschall_soundboard_play_pause_player-nr_24.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and pause of Soundboard-player #24. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=47  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_01.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_01.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #1. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=72  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_02.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_02.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #2. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=73  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_03.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_03.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #3. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=74  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_04.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_04.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #4. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=75  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_05.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_05.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #5. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=76  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_06.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_06.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #6. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=77  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_07.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_07.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #7. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=78  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_08.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_08.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #8. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=79  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_09.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_09.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #9. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=80  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_10.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_10.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #10. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=81  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_11.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_11.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #11. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=82  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_12.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_12.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #12. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=83  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_13.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_13.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #13. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=84  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_14.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_14.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #14. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=85  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_15.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_15.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #15. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=86  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_16.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_16.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #16. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=87  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_17.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_17.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #17. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=88  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_18.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_18.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #18. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=89  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_19.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_19.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #19. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=90  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_20.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_20.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #20. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=91  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_21.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_21.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #21. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=92  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_22.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_22.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #22. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=93  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_23.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_23.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #23. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=94  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_player-nr_24.lua
+++ b/Scripts/ultraschall_soundboard_play_player-nr_24.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Starts play of Soundboard-player #24. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=95  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_01.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_01.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #1. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=0  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_02.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_02.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #2. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=1  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_03.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_03.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #3. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=2  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_04.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_04.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #4. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=3  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_05.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_05.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #5. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=4  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_06.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_06.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #6. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=5  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_07.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_07.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #7. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=6  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_08.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_08.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #8. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=7  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_09.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_09.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #9. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=8  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_10.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_10.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #10. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=9  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_11.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_11.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #11. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=10  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_12.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_12.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #12. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=11  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_13.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_13.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #13. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=12  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_14.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_14.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #14. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=13  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_15.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_15.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #15. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=14  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_16.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_16.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #16. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=15  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_17.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_17.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #17. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=16  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_18.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_18.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #18. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=17  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_19.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_19.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #19. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=18  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_20.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_20.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #20. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=19  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_21.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_21.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #21. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=20  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_22.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_22.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #22. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=21  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_23.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_23.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #23. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=22  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_play_stop_player-nr_24.lua
+++ b/Scripts/ultraschall_soundboard_play_stop_player-nr_24.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Toggles play and stop of Soundboard-player #24. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0
+  MIDIModifier=144
+  Note=23  
+  Velocity=1  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_playlist_backward.lua
+++ b/Scripts/ultraschall_soundboard_playlist_backward.lua
@@ -29,6 +29,7 @@
 
 --reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", -1)
 retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
+if Position=="" then Position=0 end
 if tonumber(Position)==-1 then return end
 
 reaper.StuffMIDIMessage(0, 144,72+Position,0)

--- a/Scripts/ultraschall_soundboard_playlist_backward.lua
+++ b/Scripts/ultraschall_soundboard_playlist_backward.lua
@@ -1,0 +1,37 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+
+-- starts playing of the sounds in the SoundBoard index by index backwards
+-- track, which holds Soundboard, must be recarmed and recinput must be set to MIDI or VirtualMidiKeyboard
+
+--reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", -1)
+retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
+if tonumber(Position)==-1 then return end
+
+reaper.StuffMIDIMessage(0, 144,72+Position,0)
+reaper.StuffMIDIMessage(0, 144,72+Position-1,1)
+
+reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", Position-1)

--- a/Scripts/ultraschall_soundboard_playlist_current_position.lua
+++ b/Scripts/ultraschall_soundboard_playlist_current_position.lua
@@ -1,0 +1,3 @@
+retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
+if tonumber(Position)==-1 then Position=0 end
+reaper.MB("The current sound in the playlist is position "..(tonumber(math.tointeger(Position)+1)).." of 24", "Soundboard Playlist", 0)

--- a/Scripts/ultraschall_soundboard_playlist_current_position.lua
+++ b/Scripts/ultraschall_soundboard_playlist_current_position.lua
@@ -1,3 +1,32 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+
+-- shows the current position within all sounds in the SoundBoard
+
 retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
+if Position=="" then Position=0 end
 if tonumber(Position)==-1 then Position=0 end
 reaper.MB("The current sound in the playlist is position "..(tonumber(math.tointeger(Position)+1)).." of 24", "Soundboard Playlist", 0)

--- a/Scripts/ultraschall_soundboard_playlist_first_sound.lua
+++ b/Scripts/ultraschall_soundboard_playlist_first_sound.lua
@@ -30,6 +30,7 @@
 
 --reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", -1)
 retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
+if Position=="" then Position=0 end
 if tonumber(Position)==-1 then Position=0 end
 
 --reaper.MB("Do you want to play the first sound in the Soundboard

--- a/Scripts/ultraschall_soundboard_playlist_first_sound.lua
+++ b/Scripts/ultraschall_soundboard_playlist_first_sound.lua
@@ -1,0 +1,39 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+
+-- returns playlist to first sound in the SoundBoard index by index backwards
+-- track, which holds Soundboard, must be recarmed and recinput must be set to MIDI or VirtualMidiKeyboard
+
+
+--reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", -1)
+retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
+if tonumber(Position)==-1 then Position=0 end
+
+--reaper.MB("Do you want to play the first sound in the Soundboard
+reaper.StuffMIDIMessage(0, 144,72+Position,0)
+--reaper.StuffMIDIMessage(0, 144,72,1)
+
+reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", "-1.0")

--- a/Scripts/ultraschall_soundboard_playlist_forward.lua
+++ b/Scripts/ultraschall_soundboard_playlist_forward.lua
@@ -1,0 +1,38 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+
+-- starts playing of the sounds in the SoundBoard index by index forwards
+-- track, which holds Soundboard, must be recarmed and recinput must be set to MIDI or VirtualMidiKeyboard
+
+--reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", -1)
+retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
+if tonumber(Position)>24 then P=1 return end
+
+reaper.StuffMIDIMessage(0, 144,72+Position,0)
+reaper.StuffMIDIMessage(0, 144,72+Position+1,1)
+
+if tonumber(Position)+1>24 then Position=24 end
+reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", Position+1)

--- a/Scripts/ultraschall_soundboard_playlist_play_current_sound.lua
+++ b/Scripts/ultraschall_soundboard_playlist_play_current_sound.lua
@@ -24,16 +24,17 @@
   ################################################################################
   --]]
 
--- starts playing of the sounds in the SoundBoard index by index forwards
+-- returns playlist to first sound in the SoundBoard index by index backwards
 -- track, which holds Soundboard, must be recarmed and recinput must be set to MIDI or VirtualMidiKeyboard
+
 
 --reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", -1)
 retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
 if Position=="" then Position=0 end
-if tonumber(Position)>24 then P=1 return end
+if tonumber(Position)==-1 then Position=0 end
 
-reaper.StuffMIDIMessage(0, 144,72+Position,0)
-reaper.StuffMIDIMessage(0, 144,72+Position+1,1)
+--reaper.MB("Do you want to play the first sound in the Soundboard
+reaper.StuffMIDIMessage(0, 144,72+Position,1)
+--reaper.StuffMIDIMessage(0, 144,72,1)
 
-if tonumber(Position)+1>24 then Position=24 end
-reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", Position+1)
+

--- a/Scripts/ultraschall_soundboard_playlist_stop_current_sound.lua
+++ b/Scripts/ultraschall_soundboard_playlist_stop_current_sound.lua
@@ -24,16 +24,17 @@
   ################################################################################
   --]]
 
--- starts playing of the sounds in the SoundBoard index by index forwards
+-- returns playlist to first sound in the SoundBoard index by index backwards
 -- track, which holds Soundboard, must be recarmed and recinput must be set to MIDI or VirtualMidiKeyboard
+
 
 --reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", -1)
 retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
 if Position=="" then Position=0 end
-if tonumber(Position)>24 then P=1 return end
+if tonumber(Position)==-1 then Position=0 end
 
+--reaper.MB("Do you want to play the first sound in the Soundboard
 reaper.StuffMIDIMessage(0, 144,72+Position,0)
-reaper.StuffMIDIMessage(0, 144,72+Position+1,1)
+--reaper.StuffMIDIMessage(0, 144,72,1)
 
-if tonumber(Position)+1>24 then Position=24 end
-reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", Position+1)
+

--- a/Scripts/ultraschall_soundboard_stop_all_sounds.lua
+++ b/Scripts/ultraschall_soundboard_stop_all_sounds.lua
@@ -1,0 +1,32 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+
+-- stops playing of all sounds currently playing in the SoundBoard
+-- track, which holds Soundboard, must be recarmed and recinput must be set to MIDI or VirtualMidiKeyboard
+
+for i=0, 23 do
+  reaper.StuffMIDIMessage(0, 144,72+i,0)
+end

--- a/Scripts/ultraschall_soundboard_stop_player-nr_01.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_01.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #1. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=72  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_02.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_02.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #2. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=73  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_03.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_03.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #3. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=74  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_04.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_04.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #4. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=75  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_05.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_05.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #5. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=76  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_06.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_06.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #6. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=77  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_07.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_07.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #7. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=78  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_08.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_08.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #8. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=79  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_09.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_09.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #9. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=80  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_10.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_10.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #10. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=81  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_11.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_11.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #11. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=82  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_12.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_12.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #12. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=83  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_13.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_13.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #13. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=84  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_14.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_14.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #14. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=85  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_15.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_15.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #15. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=86  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_16.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_16.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #16. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=87  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_17.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_17.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #17. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=88  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_18.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_18.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #18. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=89  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_19.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_19.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #19. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=90  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_20.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_20.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #20. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=91  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_21.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_21.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #21. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=92  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_22.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_22.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #22. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=93  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_23.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_23.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #23. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=94  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  

--- a/Scripts/ultraschall_soundboard_stop_player-nr_24.lua
+++ b/Scripts/ultraschall_soundboard_stop_player-nr_24.lua
@@ -1,0 +1,35 @@
+  --[[
+  ################################################################################
+  # 
+  # Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+  # 
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files (the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions:
+  # 
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  # 
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  # THE SOFTWARE.
+  # 
+  ################################################################################
+  --]]
+  
+  -- Stops playing of Soundboard-player #24. 
+  -- Track with soundboard must be recarmed and have recinput set to midi or virtual midi keyboard.    
+  mode=0            -- set to virtual keyboard of Reaper
+  MIDIModifier=144  -- set to MIDI-Note
+  Note=95  
+  Velocity=0  
+  
+  reaper.StuffMIDIMessage(mode, MIDIModifier, Note, Velocity)
+  


### PR DESCRIPTION
Actions, um das Soundboard zu kontrollieren. Erfordert, dass der Soundboard-Track recarmed ist und RecInput MIDI/VirtualKeyboard hat(ist in unseren Tracktemplates zum Glück schon so drin).

Die folgenden Actions sind für Soundboard-Player-Slot 1-24:
ultraschall_soundboard_play_fadeout-pause_player-nr_01.lua bis 24.lua
ultraschall_soundboard_play_pause_player-nr_01.lua bis 24.lua
ultraschall_soundboard_play_player-nr_01.lua bis 24.lua
ultraschall_soundboard_play_stop_player-nr_01.lua bis 24.lua
ultraschall_soundboard_stop_player-nr_01.lua bis 24.lua

Die Folgende stoppt alle Sounds, die derzeit spielen. Quasi nen Panic-Button:
ultraschall_soundboard_stop_all_sounds.lua

Mit den Folgenden geht man die einzelnen Soundboard-Slots durch. Sprich, man kann den ersten Sound spielen, dann den nächsten, dann den nächsten, dann den vorherigen wieder, etc.

ultraschall_soundboard_playlist_backward.lua
ultraschall_soundboard_playlist_current_position.lua
ultraschall_soundboard_playlist_first_sound.lua
ultraschall_soundboard_playlist_forward.lua

Löst #149 