### PR TITLE
Toggle AutoFollowOff on/off funzt nun

### DIFF
--- a/Scripts/__startup.lua
+++ b/Scripts/__startup.lua
@@ -155,9 +155,11 @@ reaper.SNM_MoveOrRemoveTrackFX(m, fx_slot, 0)
 -- end
 
 -- start Followmode-reset-backgroundscript
-  follow_reset_cmdid=reaper.NamedCommandLookup("_Ultraschall_Toggle_Reset")
-  reaper.SetExtState("ultraschall_follow", "state2", follow, false)
-  reaper.Main_OnCommand(follow_reset_cmdid,0)
+  if ultraschall.GetUSExternalState("ultraschall_follow", "AutoFollowOff")~="off" then
+    follow_reset_cmdid=reaper.NamedCommandLookup("_Ultraschall_Toggle_Reset")
+    reaper.SetExtState("ultraschall_follow", "state2", follow, false)
+    reaper.Main_OnCommand(follow_reset_cmdid,0)
+  end
 
 
 --------------------------

--- a/Scripts/ultraschall_followmode_reset.lua
+++ b/Scripts/ultraschall_followmode_reset.lua
@@ -61,6 +61,7 @@ function main()
     -- here is, where the magic happens.
     
     -- check only, when Playstate isn't stopped or paused and followmode is on
+    
     if reaper.GetPlayState()~=0  
        and reaper.GetPlayState()&2~=2  -- comment, if you want to trigger AutoFollowOff during pause
        and reaper.GetExtState("follow", "skip")~="true" -- buggy line?
@@ -122,7 +123,17 @@ function main()
       reaper.SetExtState("follow", "skip", "false", false) --reset skip-state      -- buggy line?
     end
   current_time=reaper.time_precise()
-  reaper.defer(waiter)
+  if reaper.HasExtState("ultraschall_follow", "autofollowoff")==false then return else reaper.defer(waiter) end
 end
 
-main()
+function atexit()
+  reaper.DeleteExtState("ultraschall_follow", "autofollowoff", false)
+end
+
+
+if reaper.HasExtState("ultraschall_follow", "autofollowoff")==false then
+  reaper.SetExtState("ultraschall_follow", "autofollowoff", "running", false)
+  reaper.atexit(atexit)
+  main()
+end
+

--- a/Scripts/ultraschall_followmode_reset_toggle.lua
+++ b/Scripts/ultraschall_followmode_reset_toggle.lua
@@ -1,0 +1,43 @@
+--[[
+################################################################################
+#
+# Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+################################################################################
+]]
+-- Toggles AutoFollowModeOff
+-- If toggled on, it will start ultraschall_followmode_reset.lua
+-- If toggled off, it will stop the script ultraschall_followmode_reset.lua; Followmode must be de/activated manually in that case.
+
+-- 6th of December 2019
+
+dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+
+if reaper.HasExtState("ultraschall_follow", "autofollowoff")==true then
+  reaper.DeleteExtState("ultraschall_follow", "autofollowoff", false)
+  ultraschall.SetUSExternalState("ultraschall_follow", "AutoFollowOff", "off")
+  --reaper.MB("Follow Mode: Auto Off when clicking into arrangeview is turned off.\n\nFollow Mode must be started and stopped manually.", "Follow Mode", 0)
+else
+  commandid=reaper.NamedCommandLookup("_Ultraschall_Toggle_Reset")
+  reaper.Main_OnCommand(commandid,0)
+  ultraschall.SetUSExternalState("ultraschall_follow", "AutoFollowOff", "on")
+  --reaper.MB("Follow Mode: Auto Off when clicking into arrangeview is activated.\n\nFollow Mode will stop automatically when clicking into the arrangeview.", "Follow Mode", 0)
+end

--- a/ultraschall.ini
+++ b/ultraschall.ini
@@ -18,6 +18,7 @@ EnvelopeToggleState=false
 [ultraschall_follow]
 name=testbla
 state=0
+AutoFollowOff=on
 
 [ultraschall_gui]
 sec=0


### PR DESCRIPTION
Auto Follow Off kann nun getoggled werden mit der Action _Ultraschall_Toggle_Reset

Der aktuelle State ist in der ultraschall.ini zu finden:
[ultraschall_follow]
AutoFollowOff=on oder off

Der kb.ini-Eintrag ist:
SCR 516 0 Ultraschall_Toggle_Reset "Custom: ULTRASCHALL: Toggle Autostop of follow-mode on/off" ultraschall_followmode_reset_toggle.lua

Muss jetzt nur noch in den US-Settings-Dialog und dann ist das auch fertig.