### PR TITLE
PR3: ultraschall_toggle_arrange_zoom speichert Settings nun in ultraschall.ini -> ultraschall_view

### DIFF
--- a/Scripts/ultraschall_toggle_arrange_zoom.lua
+++ b/Scripts/ultraschall_toggle_arrange_zoom.lua
@@ -30,19 +30,19 @@ zoomfactor=reaper.GetHZoomLevel() -- get current zoom-level
 ZoomedInLevelDef=400              -- set this to the "zoom in"-level, you want to have
                                   -- 0.007(max zoom out) to 1000000(max zoom in) is valid,
                                   -- 400 is recommended
-Zoomstate=ultraschall.GetUSExternalState("view","zoom_toggle_state")
-ZoomedInLevel=ultraschall.GetUSExternalState("view","zoomin_level")
+Zoomstate=ultraschall.GetUSExternalState("ultraschall_view","zoom_toggle_state")
+ZoomedInLevel=ultraschall.GetUSExternalState("ultraschall_view","zoomin_level")
 ZoomedInLevel=tonumber(ZoomedInLevel)
 if ZoomedInLevel==-1 or ZoomedInLevel==nil then
   ZoomedInLevel=ZoomedInLevelDef
 end
 
 if Zoomstate=="false" or zoomfactor~=ZoomedInLevel then
-   ultraschall.SetUSExternalState("view","zoom_toggle_state","true")
-   ultraschall.SetUSExternalState("view","old_zoomfactor",zoomfactor)
+   ultraschall.SetUSExternalState("ultraschall_view","zoom_toggle_state","true")
+   ultraschall.SetUSExternalState("ultraschall_view","old_zoomfactor",zoomfactor)
    reaper.adjustZoom(ZoomedInLevel, 1, true, 0)
 else
-  ultraschall.SetUSExternalState("view","zoom_toggle_state","false")
-  oldzoomfactor=ultraschall.GetUSExternalState("view","old_zoomfactor")
+  ultraschall.SetUSExternalState("ultraschall_view","zoom_toggle_state","false")
+  oldzoomfactor=ultraschall.GetUSExternalState("ultraschall_view","old_zoomfactor")
   reaper.adjustZoom(tonumber(oldzoomfactor), 1, true, 0)
 end

--- a/ultraschall.ini
+++ b/ultraschall.ini
@@ -43,8 +43,9 @@ Safemode_Toggle=OFF
 [ultraschall_update]
 update_check=1
 
-[view]
+[ultraschall_view]
 old_zoomfactor=0.1757013744772
 zoom_toggle_state=true
 zoomin_level=400
+
 


### PR DESCRIPTION
ultraschall_toggle_arrange_zoom speichert Settings nun in ultraschall.ini -> ultraschall_view

Bitte testen, ob z-Taste noch 100% funzt auf Mac.