### PR TITLE
Timeselection/Cursormovement SpeedUp-Branch neu aufgesetzt

### DIFF
--- a/Scripts/ultraschall_move_cursor_left_creating_time_selection_SpeedUp.lua
+++ b/Scripts/ultraschall_move_cursor_left_creating_time_selection_SpeedUp.lua
@@ -1,0 +1,55 @@
+--[[
+################################################################################
+# 
+# Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# 
+################################################################################
+--]]
+
+ultraschall={}
+
+function ultraschall.GetUSExternalState(section, key)
+  -- get value
+  local A, B = reaper.BR_Win32_GetPrivateProfileString(section, key, "", reaper.GetResourcePath().."/".."ultraschall.ini")
+  return B
+end
+
+lasttime=reaper.GetExtState("ultraschall", "left_key_speedup_time_selection")
+lastfactor=reaper.GetExtState("ultraschall", "left_key_speedup_factor_time_selection")
+
+speedupfactor = ultraschall.GetUSExternalState("ultraschall_navigation", "move_cursor_and_timesel_speedup")
+if tonumber(speedupfactor)==nil then speedupfactor=0.4 else speedupfactor=tonumber(speedupfactor) end
+
+if lasttime=="" then lasttime=reaper.time_precise() end
+if lastfactor=="" then lastfactor=0 end
+
+if tonumber(lasttime)>=reaper.time_precise() then
+  lastfactor=lastfactor+speedupfactor
+else
+  lastfactor=1
+end
+
+for i=0, lastfactor do
+  reaper.Main_OnCommand(40102,0)
+end
+
+reaper.SetExtState("ultraschall", "left_key_speedup_time_selection", reaper.time_precise()+0.1, false)
+reaper.SetExtState("ultraschall", "left_key_speedup_factor_time_selection", lastfactor, false)

--- a/Scripts/ultraschall_move_cursor_right_creating_time_selection_SpeedUp.lua
+++ b/Scripts/ultraschall_move_cursor_right_creating_time_selection_SpeedUp.lua
@@ -1,0 +1,55 @@
+--[[
+################################################################################
+# 
+# Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# 
+################################################################################
+--]]
+
+ultraschall={}
+
+function ultraschall.GetUSExternalState(section, key)
+  -- get value
+  local A, B = reaper.BR_Win32_GetPrivateProfileString(section, key, "", reaper.GetResourcePath().."/".."ultraschall.ini")
+  return B
+end
+
+lasttime=reaper.GetExtState("ultraschall", "right_key_speedup_time_selection")
+lastfactor=reaper.GetExtState("ultraschall", "right_key_speedup_factor_time_selection")
+
+speedupfactor = ultraschall.GetUSExternalState("ultraschall_navigation", "move_cursor_and_timesel_speedup")
+if tonumber(speedupfactor)==nil then speedupfactor=0.4 else speedupfactor=tonumber(speedupfactor) end
+
+if lasttime=="" then lasttime=reaper.time_precise() end
+if lastfactor=="" then lastfactor=0 end
+
+if tonumber(lasttime)>=reaper.time_precise() then
+  lastfactor=lastfactor+speedupfactor
+else
+  lastfactor=1
+end
+
+for i=0, lastfactor do
+  reaper.Main_OnCommand(40103,0)
+end
+
+reaper.SetExtState("ultraschall", "right_key_speedup_time_selection", reaper.time_precise()+0.1, false)
+reaper.SetExtState("ultraschall", "right_key_speedup_factor_time_selection", lastfactor, false)

--- a/Scripts/ultraschall_move_left_one_pixel_including_speedup.lua
+++ b/Scripts/ultraschall_move_left_one_pixel_including_speedup.lua
@@ -1,0 +1,56 @@
+--[[
+################################################################################
+# 
+# Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# 
+################################################################################
+--]]
+
+ultraschall={}
+
+function ultraschall.GetUSExternalState(section, key)
+  -- get value
+  local A, B = reaper.BR_Win32_GetPrivateProfileString(section, key, "", reaper.GetResourcePath().."/".."ultraschall.ini")
+  return B
+end
+
+lasttime=reaper.GetExtState("ultraschall", "left_key_speedup")
+lastfactor=reaper.GetExtState("ultraschall", "left_key_speedup_factor")
+
+speedupfactor = ultraschall.GetUSExternalState("ultraschall_navigation", "move_cursor_speedup")
+if tonumber(speedupfactor)==nil then speedupfactor=0.4 else speedupfactor=tonumber(speedupfactor) end
+
+if lasttime=="" then lasttime=reaper.time_precise() end
+if lastfactor=="" then lastfactor=0 end
+
+if tonumber(lasttime)>=reaper.time_precise() then
+  lastfactor=lastfactor+speedupfactor
+else
+  lastfactor=1
+end
+
+
+for i=0, lastfactor do
+  reaper.Main_OnCommand(40104,0)
+end
+
+reaper.SetExtState("ultraschall", "left_key_speedup", reaper.time_precise()+0.1, false)
+reaper.SetExtState("ultraschall", "left_key_speedup_factor", lastfactor, false)

--- a/Scripts/ultraschall_move_right_one_pixel_including_speedup.lua
+++ b/Scripts/ultraschall_move_right_one_pixel_including_speedup.lua
@@ -1,0 +1,56 @@
+--[[
+################################################################################
+# 
+# Copyright (c) 2014-2019 Ultraschall (http://ultraschall.fm)
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# 
+################################################################################
+--]]
+
+ultraschall={}
+
+function ultraschall.GetUSExternalState(section, key)
+  -- get value
+  local A, B = reaper.BR_Win32_GetPrivateProfileString(section, key, "", reaper.GetResourcePath().."/".."ultraschall.ini")
+  return B
+end
+
+lasttime=reaper.GetExtState("ultraschall", "right_key_speedup")
+lastfactor=reaper.GetExtState("ultraschall", "right_key_speedup_factor")
+
+speedupfactor = ultraschall.GetUSExternalState("ultraschall_navigation", "move_cursor_speedup")
+if tonumber(speedupfactor)==nil then speedupfactor=0.4 else speedupfactor=tonumber(speedupfactor) end
+
+if lasttime=="" then lasttime=reaper.time_precise() end
+if lastfactor=="" then lastfactor=0 end
+
+if tonumber(lasttime)>=reaper.time_precise() then
+  lastfactor=lastfactor+speedupfactor
+else
+  lastfactor=1
+end
+
+
+for i=0, lastfactor do
+  reaper.Main_OnCommand(40105,0)
+end
+
+reaper.SetExtState("ultraschall", "right_key_speedup", reaper.time_precise()+0.1, false)
+reaper.SetExtState("ultraschall", "right_key_speedup_factor", lastfactor, false)


### PR DESCRIPTION
Folgendes muss noch in die kb.ini eingefügt werden, plus passende Shortcuts:

SCR 4 0 Ultraschall_Move_Cursor_Left_TimeSelection_SpeedUp "Custom: ULTRASCHALL: Move cursor left one pixel creating time-selection plus speedup" ultraschall_move_cursor_left_creating_time_selection_SpeedUp.lua
SCR 4 0 Ultraschall_Move_Cursor_Right_TimeSelection_SpeedUp "Custom: ULTRASCHALL: Move cursor right one pixel creating time-selection plus speedup" ultraschall_move_cursor_right_creating_time_selection_SpeedUp.lua
SCR 4 0 Ultraschall_Move_Cursor_Left_SpeedUp "Custom: ULTRASCHALL: Move cursor left one pixel plus speedup" ultraschall_move_left_one_pixel_including_speedup.lua
SCR 4 0 Ultraschall_Move_Cursor_Right_SpeedUp "Custom: ULTRASCHALL: Move cursor right one pixel plus speedup" ultraschall_move_right_one_pixel_including_speedup.lua
