### PR TITLE
Fixed das öffnen und schließen von Routing-Snapshots, Color Picker und Startscreen

### DIFF
--- a/Scripts/ultraschall_routing_snapshots_functions.lua
+++ b/Scripts/ultraschall_routing_snapshots_functions.lua
@@ -216,6 +216,7 @@ function Main(slot)
 end
 
 
+
 function dbg(text)
     if debug then reaper.ShowConsoleMsg(tostring(text).."\n") end
 end
@@ -612,3 +613,12 @@ function ClearHardwareSends(track) -- remove all HWOUT enries inside <track> of 
   end
   return reaper.SetTrackStateChunk(track, new_TrackStateChunk)
 end
+
+function atexit()
+  if GUI==nil then return end
+  reaper.SetExtState("Ultraschall_Windows", GUI.name, 0, false)
+end
+
+reaper.atexit(atexit)
+
+


### PR DESCRIPTION
Windowcounter für Routing-Snapshots-Window wird nun korrekt resettet.

Um mehrfaches Öffnen von ColorPicker und Startscreen zu verhindern, müssen folgende Einträge in der kb.ini AUSGETAUSCHT werden:

SCR 260 0 Ultraschall_StartScreen "Custom: ULTRASCHALL: Startscreen" ultraschall_startscreen.lua
SCR 260 0 Ultraschall_ColorPicker "Custom: ULTRASCHALL: Colorpicker" ultraschall_colorpicker.lua

Löst #254 