### PR TITLE
Öffnet nun Ordner mit äöü im Namen.

### DIFF
--- a/Scripts/ultraschall_open_project_folder.lua
+++ b/Scripts/ultraschall_open_project_folder.lua
@@ -41,8 +41,9 @@ function OpenURL(url)
   if OS == "OSX32" or OS == "OSX64" then
     os.execute('open "" "' .. url .. '"')
   else
-    os.execute('start "" "' .. url .. '"')
+    reaper.CF_ShellExecute(url)
   end
+
 end
 
 


### PR DESCRIPTION
Windows: Ordner öffnet sich nun auch mit äöü im Namen.

Löst #252 