### PR TITLE
Project Duration passt sich nun auch während der Aufnahme an

### DIFF
--- a/Scripts/ultraschall_ultraclock.lua
+++ b/Scripts/ultraschall_ultraclock.lua
@@ -53,6 +53,14 @@
 
 dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
 
+
+function GetProjectLength()
+  if reaper.GetPlayState()&4==4 and reaper.GetProjectLength()<reaper.GetPlayPosition() then
+    return reaper.GetPlayPosition()
+  else
+    return reaper.GetProjectLength()
+  end
+end
 -- Retina Management
 -- Get DPI
 retval, dpi = reaper.ThemeLayout_GetLayout("tcp", -3)
@@ -388,7 +396,7 @@ function drawClock()
   -- Project Length
   if uc_menu[6].checked then
     WriteAlignedText("Project Duration",0xb6b6bb, clockfont_bold, txt_line[9].size * fsize, txt_line[9].y*height+border,0) -- print date
-    WriteAlignedText(reaper.format_timestr_len(reaper.GetProjectLength(),"", 0,5):match("(.*):"),0xb6b6bb, clockfont_bold, txt_line[10].size * fsize, txt_line[10].y*height+border,0) -- print date
+    WriteAlignedText(reaper.format_timestr_len(GetProjectLength(),"", 0,5):match("(.*):"),0xb6b6bb, clockfont_bold, txt_line[10].size * fsize, txt_line[10].y*height+border,0) -- print date
   end
 
   -- Next/Previous Marker/Region
@@ -460,6 +468,7 @@ function MainLoop()
       reaper.SetCursorContext(1) -- Set Cursor context to the arrange window, so keystrokes work
     end
     gfx.update()
+    ALABAMASONG=GetProjectLength()
     reaper.defer(MainLoop)
   end
 end


### PR DESCRIPTION
Project Duration passt sich nun auch während der Aufnahme an

Edgecase: Wenn Aufnahme läuft und kein Track gearmed ist, zählt Project Duration auch hoch. Das ist nicht anders machbar und eh nen Edgecase. Sobald man stopp macht, geht die Duration aber wieder an die eigentliche Endstelle des Projekts.
Das ist deshalb nicht lösbar, weil gerade recordete Items nicht in GetProjectLength berücksichtigt werden, auch nicht, wenn man kurz zwischendurch den Arm-button auf unscharf stellt.
Reaper erkennt Items erst an, wenn die Aufnahme beendet wurde. Daher gehe ich einfach davon aus, dass die derzeitge Playposition während Recording an ist, auch das Ende des Projekts darstellt.

Wird sich niemand dran stören, denk ich :D

löst #266 