### PR TITLE
Ducking öffnet nicht mehr das New Instance-Fenster

### DIFF
--- a/Scripts/ultraschall_soundboard_ducking.lua
+++ b/Scripts/ultraschall_soundboard_ducking.lua
@@ -31,12 +31,15 @@ dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
 VolumeChange    = 15  -- The maximum volume-reduction of the ducking in dB; default-Value is 10dB-toggle
 Number_of_steps = 18  -- The duration of the "fadeout/fadein" of the ducking; 1 second==30 steps; default 0.66 seconds
 
-
 -- this calculates the stepsize of the volume-alteration within each defer-cycle
 Stepsize=VolumeChange/Number_of_steps
 
 -- get current toggle-state
 retval, state=reaper.GetProjExtState(0, "Ultraschall_Soundboard", "Ducking_Toggle_State")
+retval, state2=reaper.GetProjExtState(0, "Ultraschall_Soundboard", "Ducking_running")
+if state2~="" then return end
+reaper.SetProjExtState(0, "Ultraschall_Soundboard", "Ducking_running", "Hui")
+
 state=tonumber(state)
 
 if state==1 then
@@ -64,6 +67,7 @@ function main()
     Counter=Counter-1 
     reaper.defer(main) 
   else
+    reaper.SetProjExtState(0, "Ultraschall_Soundboard", "Ducking_running", "")
     if found==true then
       -- if we've found a Soundboard-track, alter toggle-state
       if state==1 then


### PR DESCRIPTION
In der kb.ini, die Zeilen:
SCR 4 0 RSd94d28a83b9213b4aff56b2e26169a460c214f13 "Custom: ultraschall_soundboard_ducking.lua" ultraschall_soundboard_ducking.lua

KEY 1 96 _RSd94d28a83b9213b4aff56b2e26169a460c214f13 0

austauschen mit:

SCR 516 0 Ultraschall_Soundboard_Ducking "Custom: ULTRASCHALL: Duckingtoggling of all Soundboard-tracks" ultraschall_soundboard_ducking.lua

KEY 1 96 _Ultraschall_Soundboard_Ducking 0

Die müssen auch an den Stellen ausgetauscht werden, wo die ursprünglichen Zeilen liegen.

Löst #267 