### PR TITLE
Versionen von SkipLookPlayback, die den View erhalten

### DIFF
--- a/Scripts/ultraschall_SkipLoopPlaybackAbsolute_KeepView.lua
+++ b/Scripts/ultraschall_SkipLoopPlaybackAbsolute_KeepView.lua
@@ -1,0 +1,37 @@
+--[[
+################################################################################
+#
+# Copyright (c) 2014-2020 Ultraschall (http://ultraschall.fm)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+################################################################################
+]]
+
+-- Meo-Ada Mespotine 
+-- like Skip loop playback, but keeps the view at the current position
+
+
+reaper.PreventUIRefresh(1)
+start_time, end_time = reaper.GetSet_ArrangeView2(0, false, 0, 0)
+cmd=reaper.NamedCommandLookup("_Ultraschall_SkipLoopPlayback_Absolute")
+reaper.Main_OnCommand(cmd, 0)
+
+reaper.BR_SetArrangeView(0, start_time, end_time)
+reaper.PreventUIRefresh(0)

--- a/Scripts/ultraschall_SkipLoopPlayback_KeepView.lua
+++ b/Scripts/ultraschall_SkipLoopPlayback_KeepView.lua
@@ -1,0 +1,37 @@
+--[[
+################################################################################
+#
+# Copyright (c) 2014-2020 Ultraschall (http://ultraschall.fm)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+################################################################################
+]]
+
+-- Meo-Ada Mespotine 
+-- like Skip loop playback absolute, but keeps the view at the current position
+
+
+reaper.PreventUIRefresh(1)
+start_time, end_time = reaper.GetSet_ArrangeView2(0, false, 0, 0)
+cmd=reaper.NamedCommandLookup("_Ultraschall_SkipLoopPlayback")
+reaper.Main_OnCommand(cmd, 0)
+
+reaper.BR_SetArrangeView(0, start_time, end_time)
+reaper.PreventUIRefresh(0)


### PR DESCRIPTION
Skripte, die Skip Loop Playback starten und dabei den Arrangeview erhalten.
Diese nutzen die bereits vorhandenen Custom Actions dafür. Das heißt, jegliche Änderungen an den Custom-Actions schlagen sich auch auf diese Skripte nieder.

Folgende Einträge müssen noch in die kb.ini:

SCR 4 0 Ultraschall_SkipLoopPlayback_Absolute_KeepView "Custom: ULTRASCHALL: Skip loop playback absolute, keep view" ultraschall_SkipLoopPlayback_KeepView.lua
SCR 4 0 Ultraschall_SkipLoopPlayback_KeepView "Custom: ULTRASCHALL: Skip loop playback, keep view" ultraschall_SkipLoopPlayback_KeepView.lua

Ich würde die nicht auf Shortcuts setzen. Wers braucht, soll das sich selbst drauf packen.