### PR TITLE
#354 fehlende Undo Blöcke

### DIFF
--- a/Scripts/ultraschall_Ripple_Cut_Selected_Tracks.lua
+++ b/Scripts/ultraschall_Ripple_Cut_Selected_Tracks.lua
@@ -33,4 +33,7 @@ if startloop==0 and startloop==endloop then reaper.MB("No time-selection active"
 
 trackstring = ultraschall.CreateTrackString_SelectedTracks()
 if trackstring=="" then reaper.MB("No tracks selected", "No track-selection", 0) return end
+
+reaper.Undo_BeginBlock()
 ultraschall.RippleCut(startloop, endloop, trackstring, true, true, false)
+reaper.Undo_EndBlock("Ripple cut in selected tracks, markers stay at their position", -1)

--- a/Scripts/ultraschall_Ripple_Cut_Selected_Tracks_Moving_Markers.lua
+++ b/Scripts/ultraschall_Ripple_Cut_Selected_Tracks_Moving_Markers.lua
@@ -34,4 +34,7 @@ if startloop==0 and startloop==endloop then reaper.MB("No time-selection active"
 
 trackstring = ultraschall.CreateTrackString_SelectedTracks()
 if trackstring=="" then reaper.MB("No tracks selected", "No track-selection", 0) return end
+
+reaper.Undo_BeginBlock()
 ultraschall.RippleCut(startloop, endloop, trackstring, true, true, true)
+reaper.Undo_EndBlock("Ripple cut in selected Tracks, moving markers", -1)

--- a/Scripts/ultraschall_Section_Cut.lua
+++ b/Scripts/ultraschall_Section_Cut.lua
@@ -31,4 +31,6 @@ dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
 startloop, endloop = reaper.GetSet_LoopTimeRange(false, false, 0, 0, false)
 if startloop==0 and startloop==endloop then reaper.MB("No time-selection active", "No time-selection", 0) return end
 
+reaper.Undo_BeginBlock()
 number_items, MediaItemArray_StateChunk = ultraschall.SectionCut(startloop, endloop, ultraschall.CreateTrackString_AllTracks(), true)
+reaper.Undo_EndBlock("Cut all items within time-selection", -1)

--- a/Scripts/ultraschall_Section_Cut_Selected_Tracks.lua
+++ b/Scripts/ultraschall_Section_Cut_Selected_Tracks.lua
@@ -33,4 +33,7 @@ if startloop==0 and startloop==endloop then reaper.MB("No time-selection active"
 
 trackstring = ultraschall.CreateTrackString_SelectedTracks()
 if trackstring=="" then reaper.MB("No tracks selected", "No track-selection", 0) return end
+
+reaper.Undo_BeginBlock()
 number_items, MediaItemArray_StateChunk = ultraschall.SectionCut(startloop, endloop, trackstring, true)
+reaper.Undo_EndBlock("Cut all items within time-selection in selected tracks", -1)


### PR DESCRIPTION
Cut all items within time-selection
Cut all items within time-selection in selected tracks
Ripple cut in selected tracks, markers stay at their position
Ripple cut in selected tracks, moving markers
