### PR TITLE
fix issue with "playlist forward" and some inconsistencies

### DIFF
--- a/Scripts/ultraschall_soundboard_playlist_first_sound.lua
+++ b/Scripts/ultraschall_soundboard_playlist_first_sound.lua
@@ -24,7 +24,7 @@
   ################################################################################
   --]]
 
--- returns playlist to first sound in the SoundBoard index by index backwards
+-- returns playlist to first sound in the SoundBoard
 -- track, which holds Soundboard, must be recarmed and recinput must be set to MIDI or VirtualMidiKeyboard
 
 

--- a/Scripts/ultraschall_soundboard_playlist_forward.lua
+++ b/Scripts/ultraschall_soundboard_playlist_forward.lua
@@ -24,7 +24,7 @@
   ################################################################################
   --]]
 
--- starts playing of the sounds in the SoundBoard index by index forwards
+-- starts play/pause of the sounds in the SoundBoard index by index forwards
 -- track, which holds Soundboard, must be recarmed and recinput must be set to MIDI or VirtualMidiKeyboard
 
 --reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", -1)

--- a/Scripts/ultraschall_soundboard_playlist_play_current_sound.lua
+++ b/Scripts/ultraschall_soundboard_playlist_play_current_sound.lua
@@ -24,14 +24,16 @@
   ################################################################################
   --]]
 
--- returns playlist to first sound in the SoundBoard index by index backwards
+-- play/pause sound at current index in the SoundBoard
 -- track, which holds Soundboard, must be recarmed and recinput must be set to MIDI or VirtualMidiKeyboard
 
 
 --reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", -1)
 retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
-if Position=="" then Position=0 end
-if tonumber(Position)==-1 then Position=0 end
+if Position=="" or tonumber(Position)==-1 then 
+  Position=0 
+  reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", Position)
+end
 
 --reaper.MB("Do you want to play the first sound in the Soundboard
 reaper.StuffMIDIMessage(0, 144,24+Position,1)

--- a/Scripts/ultraschall_soundboard_playlist_stop_current_sound.lua
+++ b/Scripts/ultraschall_soundboard_playlist_stop_current_sound.lua
@@ -24,14 +24,16 @@
   ################################################################################
   --]]
 
--- returns playlist to first sound in the SoundBoard index by index backwards
+-- stop/play sound at current index in the SoundBoard
 -- track, which holds Soundboard, must be recarmed and recinput must be set to MIDI or VirtualMidiKeyboard
 
 
 --reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", -1)
 retval, Position=reaper.GetProjExtState(0, "ultraschall_soundboard", "playlistindex")
-if Position=="" then Position=0 end
-if tonumber(Position)==-1 then Position=0 end
+if Position=="" or tonumber(Position)==-1 then 
+  Position=0 
+  reaper.SetProjExtState(0, "ultraschall_soundboard", "playlistindex", Position)
+end
 
 --reaper.MB("Do you want to play the first sound in the Soundboard
 reaper.StuffMIDIMessage(0, 144,0+Position,1)


### PR DESCRIPTION
"play current" didn't advance index when used after "playlist first". Executing "playlist next" afterwards played the first sound again.
The same was true for "playlist stop".
Additionally fixed script descriptions.
(There is a remaining issue with the initial state of the Sound Board, where "playlist forward" doesn't play the first sound, but rather the second one. So the state after "playlist first" differs from the initial state.)

<!--
Please make sure you have ticked all points on this checklist:

- [ ] If your changes are large or otherwise disruptive: You have made sure your changes don't interfere with current development by talking it through with the maintainers, e.g. through a Brainstorming ticket
- [ ] Your PR targets Ultraschall's development branch (3.x), or maintenance if it's a bug fix for an issue present in the current stable version (no PRs against master or anything else please)
- [ ] Your PR was opened from a custom branch on your repository (no PRs from your version of master, maintenance or development please), e.g. dev/my_new_feature or fix/my_bugfix
- [ ] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase and squash your PR if necessary!
- [ ] Your changes follow the existing coding style
- [ ] You have tested your changes (please state how!)
-->

<!--
Describe your PR further using the template provided below. The more details the better!
-->

**What does this PR do and why is it necessary?**
Using the playlist actions was somewhat unpredictable, especially at the beginning of the playlist and after using the "playlist first" script. The behavior is more consistent now.

**How was it tested? How can it be tested by the reviewer?**
- Create new Soundboard track
- rec-arm track
- fill Soundboard with sounds
- use "playlist" actions/scripts to navigate between sounds

**Any background context you want to provide?**

I would also recommend to make the script descriptions/names more clear. The "play current" and "stop current" are actually "play/pause" and "play/stop" actions. "playlist forward" doesn't just go forward but also plays the next sound, whereas "playlist first" goes to the beginning without playing the sound.
I might work on another PR for this.

**What are the relevant tickets if any?**

**Screenshots (if appropriate)**

**Further notes**
