### PR TITLE
LUFS-Monitoring-JSFX: Font Fix und erweiterte Funktionalität

### DIFF
--- a/Effects/dynamics/LUFS_Loudness_Meter
+++ b/Effects/dynamics/LUFS_Loudness_Meter
@@ -208,8 +208,9 @@ gmem[2] = -16; // LUFS Target
 gmem[3] = 0; // is FX active?
 gmem[4] = 0; // Reset button: set this via ReaScript to 1 to reset the indicator (reaper.gmem_attach and reaper.gmem_write)
 gmem[5] = 0; // Match Gain: set this via ReaScript to 1 to match gain (reaper.gmem_attach and reaper.gmem_write)
-
-
+gmem[6] = slider5; // The gain currently set in the JSFX-UI
+gmem[7] = -10000; // Set the gain in this gmem from ReaScript
+gmem[8] = -10000; // Set the target in this gmem from ReaScript; the number order is the same as in the dropdownlist
 lufs_store = MM.MemMgr_Alloc(999);
 
 loopcount = 1;
@@ -252,6 +253,7 @@ function adjustGain()
 
 lufs_target = -14 - 2*slider7;
 gmem[2] = lufs_target;
+gmem[6] = slider5;
 slider7 == 4? (
   lufs_target = -23;
 );
@@ -432,6 +434,15 @@ gmem[5]>0 ? (
   gmem[5]=0;
 );
 
+gmem[7]>-10000 ? (
+  slider5=gmem[7];
+  gmem[7]=-10000;
+);
+
+gmem[8]>-10000 ? (
+  slider7=gmem[8];
+  gmem[8]=-10000;
+);
 gfx_ext_retina>1 ? gfx_setfont(1,"Arial",14*gfx_ext_retina,'b') : gfx_setfont(1, "Arial", 14, 'b');
 
 

--- a/Effects/dynamics/LUFS_Loudness_Meter
+++ b/Effects/dynamics/LUFS_Loudness_Meter
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////////////////
 // LUFS Loudness Metering (Ultraschall)
-// Copyright (c) 2021 Ultraschall (http://ultraschall.fm)
+// Copyright (c) 2022 Ultraschall (http://ultraschall.fm)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -206,6 +206,9 @@ no_meters = 0;
 gmem[1] = 0; // LUFS integral
 gmem[2] = -16; // LUFS Target
 gmem[3] = 0; // is FX active?
+gmem[4] = 0; // Reset button: set this via ReaScript to 1 to reset the indicator (reaper.gmem_attach and reaper.gmem_write)
+gmem[5] = 0; // Match Gain: set this via ReaScript to 1 to match gain (reaper.gmem_attach and reaper.gmem_write)
+
 
 lufs_store = MM.MemMgr_Alloc(999);
 
@@ -417,8 +420,19 @@ spl1 = spl_lufs1;
 @gfx 0 32 // request horizontal/vertical heights (0 means dont care)
 //////////////////////////////////////////////////////////////////////////////////
 
+gmem[4]>0 ? (
+  EBUR128LM.LM_EBUR128_Reset_MultiCh();
+  clearHistory();
+  position = 100;
+  gmem[4]=0;
+);
 
-gfx_ext_retina>1 ? gfx_setfont(1,"Arial",14*gfx_ext_retina,'b') : gfx_setfont(0);
+gmem[5]>0 ? (
+  adjustGain();
+  gmem[5]=0;
+);
+
+gfx_ext_retina>1 ? gfx_setfont(1,"Arial",14*gfx_ext_retina,'b') : gfx_setfont(1, "Arial", 14, 'b');
 
 
   gr_meter = reduction;


### PR DESCRIPTION
Der Font für nicht Retina-Auflösungen war der Default-Font. Hab den mal auf Arial geändert, weil schicker.

Man kann die Buttons nun auch von ReaScript aus steuern:
reaper.gmem_attach("lufs")
dann
GMEM[4] auf 1 setzen löst den "Reset"-Button aus.
GMEM[5] auf 1 setzen löst den "Match Gain"-Button aus.

Damit ists z.B. der Ultraclock möglich, das LUFS-Metering zu resetten, ohne dass man den Effekt offen haben muss.

