### PR TITLE
Smoother ZoomOut, wenn sehr weit aus dem Projekt rausgezoomed wird

### DIFF
--- a/Scripts/ultraschall_zoomlimiter.lua
+++ b/Scripts/ultraschall_zoomlimiter.lua
@@ -55,8 +55,7 @@ end
 
     steplength = 0.4 -- factor to adjust the steplength of the zoom
     sensitivity = tonumber(ultraschall.GetUSExternalState("ultraschall_settings_Zoom_Sensitivity", "Value", "ultraschall-settings.ini"))
-    if sensitivity==nil then sensitivity = 4 end -- 0.4-4 are useful values
-    sensitivity=4
+    if sensitivity==nil then sensitivity = 5 end -- 0.4-4 are useful values
     length=0
     
     --get end of project or position of play/editcursor in the project, depending on what is the last

--- a/Scripts/ultraschall_zoomlimiter.lua
+++ b/Scripts/ultraschall_zoomlimiter.lua
@@ -24,15 +24,39 @@
 ################################################################################
 ]]
 
+-- Adjusts zoom stepwise.
+-- Will limit the zoom out from 0 to projectlength+edit/play-cursor, depending on what is the last.
+
 -- Print Message to console (debugging)
 function Msg(val)
   reaper.ShowConsoleMsg(tostring(val).."\n")
 end
 
--- Adjusts zoom stepwise.
--- Will limit the zoom out from 0 to projectlength+edit/play-cursor, depending on what is the last.
+_,_,_,_,mode,res,val = reaper.get_action_context()
+
+ultraschall={}
+function ultraschall.GetIniFileValue(section, key, errval, inifile)
+-- returns the trackname as a string
+  if errval==nil then errval="" end
+  section=tostring(section)
+  key=tostring(key)
+
+  return reaper.BR_Win32_GetPrivateProfileString(section, key, errval, inifile)
+end
+
+function ultraschall.GetUSExternalState(section, key, filename)
+-- gets a value from ultraschall.ini
+-- returns length of entry(integer) and the entry itself(string)
+  -- get value
+  local A, B = ultraschall.GetIniFileValue(section, key, "", reaper.GetResourcePath().."/"..filename)
+  if A==-1 then B="" end
+  return B
+end
 
     steplength = 0.4 -- factor to adjust the steplength of the zoom
+    sensitivity = tonumber(ultraschall.GetUSExternalState("ultraschall_settings_Zoom_Sensitivity", "Value", "ultraschall-settings.ini"))
+    if sensitivity==nil then sensitivity = 4 end -- 0.4-4 are useful values
+    sensitivity=4
     length=0
     
     --get end of project or position of play/editcursor in the project, depending on what is the last
@@ -43,16 +67,23 @@ end
     else
       length=reaper.GetProjectLength()
     end
-  
+
 if length<180 then length=180 end   -- zoomlimit does not apply under 3 minutes
-    
-    _,_,_,_,mode,res,val = reaper.get_action_context()
     if mode==-1 and res==-1 and val==-1 then val=0 end
     
-    val = val * steplength
-
+    
     start_time, end_time = reaper.GetSet_ArrangeView2(0, false, 0, 0)
-        
+    
+    if end_time-start_time>1500 then
+      steplength=steplength/2^(sensitivity+1)
+    --elseif end_time-start_time<3600 and end_time-start_time>1500 then
+--      steplength=steplength/2^(sensitivity+1)
+    elseif end_time-start_time<1500 then
+      steplength=steplength/2^sensitivity
+    end
+    
+    val = val * steplength    
+    
     if val<0 and end_time-start_time-((end_time-start_time)/5)>length then
         -- reaper.Main_OnCommand(40295,0)
         reaper.SetExtState("ultraschall_follow", "started", "started", false)


### PR DESCRIPTION
Zoomt nun smoother raus, wenn viel vom Projekt zu sehen ist. Vorher sprang es in großen Schritten von 1 Stunde zu 2 Stunden zu 8 Stunden, etc

Die Smoothness kann in der settings.ini gesetzt werden(0.4-4):

"ultraschall-settings.ini": "ultraschall_settings_Zoom_Sensitivity" ->"Value"

gewünscht von Simon:
https://sendegate.de/t/horizontal-zoom-intensitaet-mausrad/16177

<!--
Please make sure you have ticked all points on this checklist:

- [ ] If your changes are large or otherwise disruptive: You have made sure your changes don't interfere with current development by talking it through with the maintainers, e.g. through a Brainstorming ticket
- [ ] Your PR targets Ultraschall's development branch (3.x), or maintenance if it's a bug fix for an issue present in the current stable version (no PRs against master or anything else please)
- [ ] Your PR was opened from a custom branch on your repository (no PRs from your version of master, maintenance or development please), e.g. dev/my_new_feature or fix/my_bugfix
- [ ] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase and squash your PR if necessary!
- [ ] Your changes follow the existing coding style
- [ ] You have tested your changes (please state how!)
-->

<!--
Describe your PR further using the template provided below. The more details the better!
-->

**What does this PR do and why is it necessary?**

**How was it tested? How can it be tested by the reviewer?**

**Any background context you want to provide?**

**What are the relevant tickets if any?**

**Screenshots (if appropriate)**

**Further notes**
