### PR TITLE
Manual Ducking beim Bauen

### DIFF
--- a/Scripts/ultraschall_ducking_of_selected_tracks_within_time_selection(volume_prefx-envelope).lua
+++ b/Scripts/ultraschall_ducking_of_selected_tracks_within_time_selection(volume_prefx-envelope).lua
@@ -31,25 +31,25 @@ dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
 -- lowers the volume of selected tracks within time-selection by adding envelope-points into the volume(pre fx)-envelope
 -- Good for ducking underlying music under spoken words.
 
--- following settings in ultraschall.ini -> [ultraschall_manual_track_ducking]
+-- following settings in ultraschall-settings.ini -> [ultraschall_manual_track_ducking]
 -- FadeInLength -- fade-in length in seconds
 -- FadeOutLength -- fade-out length in seconds
 -- LowerBydB - the dB to lower by(negative values will make volume louder instead of more silent)
 -- Tension - the tension of the envelope-shape(0-1 are useful values)
 -- Shape - the shape of the envelope-points(0-5)
-FadeInLength=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "FadeInLength", "ultraschall.ini"))
+FadeInLength=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "FadeInLength", "ultraschall-settings.ini"))
 if FadeInLength==nil then FadeInLength=0.5 end
 
-FadeOutLength=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "FadeOutLength", "ultraschall.ini"))
+FadeOutLength=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "FadeOutLength", "ultraschall-settings.ini"))
 if FadeOutLength==nil then FadeOutLength=0.5 end
 
-LowerBydB=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "LowerBydB", "ultraschall.ini"))
+LowerBydB=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "LowerBydB", "ultraschall-settings.ini"))
 if LowerBydB==nil then LowerBydB=8 end
 
-Tension=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "Tension", "ultraschall.ini"))
+Tension=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "Tension", "ultraschall-settings.ini"))
 if Tension==nil then Tension=0 end
 
-Shape=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "Shape", "ultraschall.ini"))
+Shape=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "Shape", "ultraschall-settings.ini"))
 if Shape==nil then Shape=0 end
 
 --if lol==nil then return end

--- a/Scripts/ultraschall_ducking_of_selected_tracks_within_time_selection(volume_prefx-envelope).lua
+++ b/Scripts/ultraschall_ducking_of_selected_tracks_within_time_selection(volume_prefx-envelope).lua
@@ -1,0 +1,91 @@
+--[[
+################################################################################
+#
+# Copyright (c) Ultraschall (http://ultraschall.fm)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+################################################################################
+]]
+
+
+dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+
+-- ultraschall-manual ducking - Meo-Ada Mespotine 7th of November 2022
+-- lowers the volume of selected tracks within time-selection by adding envelope-points into the volume(pre fx)-envelope
+-- Good for ducking underlying music under spoken words.
+
+-- following settings in ultraschall.ini -> [ultraschall_manual_track_ducking]
+-- FadeInLength -- fade-in length in seconds
+-- FadeOutLength -- fade-out length in seconds
+-- LowerBydB - the dB to lower by(negative values will make volume louder instead of more silent)
+-- Tension - the tension of the envelope-shape(0-1 are useful values)
+-- Shape - the shape of the envelope-points(0-5)
+FadeInLength=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "FadeInLength", "ultraschall.ini"))
+if FadeInLength==nil then FadeInLength=0.5 end
+
+FadeOutLength=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "FadeOutLength", "ultraschall.ini"))
+if FadeOutLength==nil then FadeOutLength=0.5 end
+
+LowerBydB=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "LowerBydB", "ultraschall.ini"))
+if LowerBydB==nil then LowerBydB=8 end
+
+Tension=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "Tension", "ultraschall.ini"))
+if Tension==nil then Tension=0 end
+
+Shape=tonumber(ultraschall.GetUSExternalState("ultraschall_manual_track_ducking", "Shape", "ultraschall.ini"))
+if Shape==nil then Shape=0 end
+
+--if lol==nil then return end
+start_time, end_time = reaper.GetSet_LoopTimeRange(false, false, 0, 0, false)
+if FadeInLength+FadeOutLength>end_time-start_time then
+  reaper.MB("Time-Selection must be at least "..FadeInLength+FadeOutLength.." seconds long for the fade in+out to happen(you can change this in the settings)", "Time selection too short", 0)
+  return
+end
+
+if reaper.CountSelectedTracks(0)==0 then reaper.MB("At least one track must be selected.", "No track selected", 0) return end
+
+Selected_Tracks={}
+for i=0, reaper.CountSelectedTracks(0) do
+  Selected_Tracks[i]=reaper.GetSelectedTrack(0, i)
+end
+
+for i=0, #Selected_Tracks do
+  track_nr=reaper.GetMediaTrackInfo_Value(Selected_Tracks[i], "IP_TRACKNUMBER")
+  retval = ultraschall.ActivateTrackPreFXVolumeEnv(math.tointeger(track_nr))
+
+  local A=reaper.GetTrackEnvelopeByName(Selected_Tracks[i], "Volume (Pre-FX)")
+
+  -- delete already existing envelope-points
+  reaper.DeleteEnvelopePointRange(A, start_time, end_time+0.0000000001)
+  
+  -- insert start/end-envelope-points
+  local _, B = reaper.Envelope_Evaluate(A, start_time, 48000, 100)
+  reaper.InsertEnvelopePoint(A, start_time, B, Shape, Tension, false, true)
+  local _, B2=reaper.Envelope_Evaluate(A, end_time, 48000, 10)
+  reaper.InsertEnvelopePoint(A, end_time, B, 0, 0, false, true)
+  
+  
+  -- insert fadein/out-envelope points
+  local B=reaper.SLIDER2DB(B)
+  local C=reaper.DB2SLIDER(B-LowerBydB)
+  reaper.InsertEnvelopePoint(A, start_time+FadeInLength, C, 0, 0, false, true)
+  reaper.InsertEnvelopePoint(A, end_time-FadeInLength, C, Shape, Tension, false, true)
+  reaper.Envelope_SortPoints(A)
+end


### PR DESCRIPTION
Erster Aufschlag der Funktion.

Ducking von Spuren in der Post-Produktion.

Man selektiert die Tracks und dann macht man eine Time-Selection. Dann das Skript ausführen und in die Volume-PreFX-Automationsspuren werden passende Envelopes eingezeichnet zum Senken der Lautstärke.

Es senkt die Lautstärke relativ zur bereits eingezeichneten Lautstärke. Wenn also etwas bereits um 3dB abgesenkt ist, wird es noch weiter abgesenkt. Ists an anderer Stelle 0dB, wird das abgesenkt.

Das ist praktisch, wenn man mal schnell ein Musikbett absenken möchte in der Nachbearbeitung oder für gebaute Beiträge.

Die einzelnen Parameter lassen sich per ultraschall.ini setzen(siehe Skript), das kann also relativ einfach in den Settings-Dialog eingebaut werden.

Der Default ist 8dB Absenkung, kann aber in der ultraschall.ini angepasst werden.

Vorgeschlagen von @tomtjes