### PR TITLE
Ripple Cut 2.0

### DIFF
--- a/Scripts/__startup.lua
+++ b/Scripts/__startup.lua
@@ -124,7 +124,7 @@ end
 ]]
 
 --------------------------
--- Restore / set GUI states
+-- Restore / set GUI/toggle states
 --------------------------
 
 mouse_id = reaper.NamedCommandLookup("_Ultraschall_Toggle_Mouse_Selection")
@@ -167,6 +167,23 @@ on_air_button_id = reaper.NamedCommandLookup("_Ultraschall_OnAir")
 reaper.SetToggleCommandState(0, on_air_button_id, 0)
 reaper.RefreshToolbar2(0, on_air_button_id)
 
+
+--[[ set current toggling-action-states that have no toolbar-button ]]
+
+-- get command_ids
+ripple_cut_ignore_locked_tracks=reaper.NamedCommandLookup("_Ultraschall_Ripple_Cut_Ignore_Locked_Tracks")
+ripple_cut_obey_crossfade=reaper.NamedCommandLookup("_Ultraschall_Ripple_Cut_Obey_Crossfade")
+ripple_cut_review_edits=reaper.NamedCommandLookup("_Ultraschall_Ripple_Cut_Review_Toggle")
+
+-- get their current toggle-settings
+ripple_cut_review_edits2 = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "review_edit_toggle","ultraschall-settings.ini")
+ripple_cut_ignore_locked_tracks2 = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "obey_locked_toggle","ultraschall-settings.ini")
+ripple_cut_obey_crossfade2 = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "obey_crossfade_toggle","ultraschall-settings.ini")
+
+-- set toggle-states
+if ripple_cut_review_edits2=="true" then reaper.SetToggleCommandState(0, ripple_cut_review_edits, 1) else reaper.SetToggleCommandState(0, ripple_cut_review_edits, 0) end
+if ripple_cut_ignore_locked_tracks2=="true" then reaper.SetToggleCommandState(0, ripple_cut_ignore_locked_tracks, 1) else reaper.SetToggleCommandState(0, ripple_cut_ignore_locked_tracks, 0) end
+if ripple_cut_obey_crossfade2=="true" then reaper.SetToggleCommandState(0, ripple_cut_obey_crossfade, 1) else reaper.SetToggleCommandState(0, ripple_cut_obey_crossfade, 0) end
 
 --------------------------
 -- Restore opened/closed Windows

--- a/Scripts/ultraschall_ripple_cut_setting_ignore_locked_tracks_toggle.lua
+++ b/Scripts/ultraschall_ripple_cut_setting_ignore_locked_tracks_toggle.lua
@@ -1,0 +1,36 @@
+--[[
+################################################################################
+#
+# Copyright (c) 2014-present Ultraschall (http://ultraschall.fm)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+################################################################################
+]]
+dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+_,_,secID,cmdID = reaper.get_action_context()
+
+obey_locked_toggle = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "obey_locked_toggle","ultraschall-settings.ini")
+if obey_locked_toggle=="true" then 
+  ultraschall.SetUSExternalState("ultraschall_settings_ripplecut", "obey_locked_toggle", "false", "ultraschall-settings.ini") 
+  reaper.SetToggleCommandState(secID, cmdID, 0)
+else 
+  ultraschall.SetUSExternalState("ultraschall_settings_ripplecut", "obey_locked_toggle", "true", "ultraschall-settings.ini") 
+  reaper.SetToggleCommandState(secID, cmdID, 1)
+end

--- a/Scripts/ultraschall_ripple_cut_setting_obey_crossfade.lua
+++ b/Scripts/ultraschall_ripple_cut_setting_obey_crossfade.lua
@@ -1,0 +1,36 @@
+--[[
+################################################################################
+#
+# Copyright (c) 2014-present Ultraschall (http://ultraschall.fm)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+################################################################################
+]]
+dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+_,_,secID,cmdID = reaper.get_action_context()
+
+obey_crossfade_toggle = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "obey_crossfade_toggle","ultraschall-settings.ini")
+if obey_crossfade_toggle=="true" then 
+  ultraschall.SetUSExternalState("ultraschall_settings_ripplecut", "obey_crossfade_toggle", "false", "ultraschall-settings.ini") 
+  reaper.SetToggleCommandState(secID, cmdID, 0)
+else 
+  ultraschall.SetUSExternalState("ultraschall_settings_ripplecut", "obey_crossfade_toggle", "true", "ultraschall-settings.ini") 
+  reaper.SetToggleCommandState(secID, cmdID, 1)
+end

--- a/Scripts/ultraschall_ripple_cut_setting_review_edit_toggle.lua
+++ b/Scripts/ultraschall_ripple_cut_setting_review_edit_toggle.lua
@@ -1,0 +1,36 @@
+--[[
+################################################################################
+#
+# Copyright (c) 2014-present Ultraschall (http://ultraschall.fm)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+################################################################################
+]]
+dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+_,_,secID,cmdID = reaper.get_action_context()
+
+review_toggle = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "review_edit_toggle","ultraschall-settings.ini")
+if review_toggle=="true" then 
+  ultraschall.SetUSExternalState("ultraschall_settings_ripplecut", "review_edit_toggle", "false", "ultraschall-settings.ini") 
+  reaper.SetToggleCommandState(secID, cmdID, 0)
+else 
+  ultraschall.SetUSExternalState("ultraschall_settings_ripplecut", "review_edit_toggle", "true", "ultraschall-settings.ini") 
+  reaper.SetToggleCommandState(secID, cmdID, 1)
+end

--- a/Scripts/ultraschall_ripplecut_2.0.lua
+++ b/Scripts/ultraschall_ripplecut_2.0.lua
@@ -51,6 +51,8 @@ init_start_timesel, init_end_timesel = reaper.GetSet_LoopTimeRange(false, 0, 0, 
 preroll = tonumber(ultraschall.GetUSExternalState("ultraschall_settings_preroll", "value","ultraschall-settings.ini"))
 review_toggle = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "review_edit_toggle","ultraschall-settings.ini")
 obey_locked = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "obey_locked_toggle","ultraschall-settings.ini")
+obey_crossfade = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "obey_crossfade_toggle","ultraschall-settings.ini")
+if obey_crossfade~="true" then obey_crossfade=false else obey_crossfade=true end
 
 -------------------------------------
 reaper.Undo_BeginBlock() -- Beginning of the undo block. Leave it at the top of your main function.
@@ -69,7 +71,7 @@ if (init_end_timesel ~= init_start_timesel) then    -- there is a time selection
                                                                  true, -- moveenvelopepoints, 
                                                                  true, -- add_to_clipboard, 
                                                                  true, -- movemarkers, 
-                                                                 nil)-- obey_crossfade)
+                                                                 obey_crossfade)-- obey_crossfade)
   AddMuteEnvelopePoint_IfNecessary(init_start_timesel, init_end_timesel)
   -- Store Outtakes
   

--- a/Scripts/ultraschall_ripplecut_2.0.lua
+++ b/Scripts/ultraschall_ripplecut_2.0.lua
@@ -1,0 +1,151 @@
+--[[
+################################################################################
+#
+# Copyright (c) 2014-present Ultraschall (http://ultraschall.fm)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+################################################################################
+]]
+dofile(reaper.GetResourcePath().."/UserPlugins/ultraschall_api.lua")
+
+
+function AddMuteEnvelopePoint_IfNecessary(startsel)
+  for i=1, reaper.CountTracks(0) do
+    Track=reaper.GetTrack(0,i-1)
+    Envelope=reaper.GetTrackEnvelopeByName(Track, "Mute")
+    retval, envIDX, envVal = ultraschall.IsMuteAtPosition(i, startsel)
+
+    if retval==false and Envelope~=nil then
+      envIDX, envVal, envPosition = ultraschall.GetPreviousMuteState(i, startsel)
+      if envIDX~=-1 then reaper.InsertEnvelopePoint(Envelope, startsel, envVal, 1, 0, false, false) end
+    end
+  end
+end
+
+
+--AddMuteEnvelopePoint_IfNecessary(10, 11)
+
+--if lol==nil then return end
+
+playstate=reaper.GetPlayState()
+playpos=reaper.GetPlayPosition()
+if playstate&4==4 then return end -- quit if recording
+init_start_timesel, init_end_timesel = reaper.GetSet_LoopTimeRange(false, 0, 0, 0, 0)
+preroll = tonumber(ultraschall.GetUSExternalState("ultraschall_settings_preroll", "value","ultraschall-settings.ini"))
+review_toggle = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "review_edit_toggle","ultraschall-settings.ini")
+obey_locked = ultraschall.GetUSExternalState("ultraschall_settings_ripplecut", "obey_locked_toggle","ultraschall-settings.ini")
+
+-------------------------------------
+reaper.Undo_BeginBlock() -- Beginning of the undo block. Leave it at the top of your main function.
+-------------------------------------
+
+if (init_end_timesel ~= init_start_timesel) then    -- there is a time selection
+  if obey_locked~="true" then
+    unlocked_trackstring = ultraschall.CreateTrackString_AllTracks()
+  else
+    locked_trackstring, unlocked_trackstring = ultraschall.GetAllLockedTracks()
+  end
+  -- Ripple Cut
+  number_items, MediaItemStateChunkArray = ultraschall.RippleCut(init_start_timesel, 
+                                                                 init_end_timesel, 
+                                                                 unlocked_trackstring, 
+                                                                 true, -- moveenvelopepoints, 
+                                                                 true, -- add_to_clipboard, 
+                                                                 true, -- movemarkers, 
+                                                                 nil)-- obey_crossfade)
+  AddMuteEnvelopePoint_IfNecessary(init_start_timesel, init_end_timesel)
+  -- Store Outtakes
+  
+  -- get old maximum outtake-items and endposition of future outtake-project
+  retval, old_max_items=reaper.GetProjExtState(0, "ultraschall_outtakes", "max_items")
+  old_max_items=tonumber(old_max_items)
+  if old_max_items==nil then old_max_items=0 end
+  
+  retval, old_max_position=reaper.GetProjExtState(0, "ultraschall_outtakes", "max_position")
+  old_max_position=tonumber(old_max_position)
+  if old_max_position==nil then old_max_position=0 end
+  
+  -- get the maximum/minimum time of the outtakes
+  minimum_time=reaper.GetProjectLength(0)
+  maximum_time=0
+  for i=1, #MediaItemStateChunkArray do
+    position = ultraschall.GetItemPosition(nil, MediaItemStateChunkArray[i])
+    length = ultraschall.GetItemLength(nil, MediaItemStateChunkArray[i])
+    endposition=position+length
+    if position<minimum_time then minimum_time=position end
+    if endposition>maximum_time then maximum_time=endposition end
+  end
+  
+  -- move position of outtakes to useful final position in future outtake-project
+  for i=1, #MediaItemStateChunkArray do
+    position = ultraschall.GetItemPosition(nil, MediaItemStateChunkArray[i])
+    MediaItemStateChunkArray[i] = ultraschall.SetItemPosition(nil, ((position-minimum_time)+old_max_position), MediaItemStateChunkArray[i])
+  end
+  
+  -- store the outtakes into projextstates
+  reaper.SetProjExtState(0, "ultraschall_outtakes", "max_items",  old_max_items+#MediaItemStateChunkArray)
+  reaper.SetProjExtState(0, "ultraschall_outtakes", "max_position", old_max_position+(maximum_time-minimum_time))
+  
+  for i=1, #MediaItemStateChunkArray do
+    reaper.SetProjExtState(0, "ultraschall_outtakes", "item_nr_"..(old_max_items+i), MediaItemStateChunkArray[i])
+  end                                                                  
+  
+  if (playstate==0 or playstate&2==2) then -- pause/stop -> move to start of selection
+    reaper.MoveEditCursor(init_start_timesel-reaper.GetCursorPosition(), 0)
+  else
+    if (playpos>=init_start_timesel and playpos<init_end_timesel) then -- playpos is inside the selection -> jump to start of selection (we have o use pause/setpos/play)
+      reaper.OnPauseButton() --pause
+      if review_toggle~="true" then
+        reaper.MoveEditCursor(init_start_timesel-reaper.GetPlayPosition(), 0)
+      else
+        reaper.MoveEditCursor(init_start_timesel-reaper.GetPlayPosition()-preroll, 0)
+      end
+      reaper.OnPlayButton() --play
+      
+    elseif (playpos>init_end_timesel) then -- if playpos is right from selection move cursor to the left to keep relative playpos
+      reaper.OnPauseButton() --pause
+      if review_toggle~="true" then
+        reaper.MoveEditCursor(-(init_end_timesel-init_start_timesel), 0)
+      else
+        reaper.MoveEditCursor(-(reaper.GetProjectLength(0)), 0)
+        reaper.MoveEditCursor(init_start_timesel-preroll, 0)
+      end
+      reaper.OnPlayButton() --play
+    elseif (playpos<init_start_timesel) then
+      if review_toggle=="true" then
+        reaper.OnPauseButton() --pause
+        reaper.MoveEditCursor(-(reaper.GetProjectLength(0)), 0)
+        reaper.MoveEditCursor(init_start_timesel-preroll, 0)
+        reaper.OnPlayButton() --play
+      end
+    end
+
+    if followstate==1 then -- reactivate followmode if it was on before
+      ultraschall.pause_follow_one_cycle()
+      reaper.Main_OnCommand(followon_actionnumber,0)
+    end 
+  end
+else                           -- no time selection or items selected
+   result = reaper.ShowMessageBox( "You need to make a time selection to ripple-cut.", "Ultraschall Ripple Cut", 0 )  -- Info window
+end
+reaper.GetSet_LoopTimeRange(true, 0, 0, 0, 0)
+reaper.Undo_EndBlock("Ultraschall Ripple Cut", -1) -- End of the undo block. Leave it at the bottom of your main function.
+
+reaper.UpdateArrange()

--- a/reaper-kb.ini
+++ b/reaper-kb.ini
@@ -67,7 +67,8 @@ SCR 4 0 Ultraschall_Open_Project_Folder "File: Open project folder (Ultraschall)
 SCR 4 0 Ultraschall_Select_StudioLink "Track: Select Studiolink (Ultraschall)" ultraschall_select_studiolink.lua
 SCR 4 0 Ultraschall_Prepare_For_Editing "Edit: Prepare all tracks for editing (Ultraschall)" ultraschall_prepare_for_editing.lua
 SCR 4 0 Ultraschall_MetaData "Extras: Metadata (Ultraschall)" ultraschall_metadata.lua
-SCR 4 0 Ultraschall_Ripple_Cut "Time selection: Ripplecut (Ultraschall)" ultraschall_ripple_cut.lua
+SCR 4 0 Ultraschall_Ripple_Cut "Time selection: Ripplecut (Ultraschall)" ultraschall_ripplecut_2.0.lua
+SCR 4 0 Ultraschall_Insert_Outtakes_Into_New_Project "Outtakes: Insert Outtakes into new project (Ultraschall)" ultraschall_insert_outtakes.lua
 SCR 4 0 Ultraschall_Toggle_Track_Height "Workspace: Toggle trackheight (Ultraschall)" ultraschall_toggle_track_height.lua
 SCR 4 0 Ultraschall_Routing_Snapshots_Functions "Routing: Routing snapshots-functions (Ultraschall)" ultraschall_routing_snapshots_functions.lua
 SCR 4 0 Ultraschall_Gui_Lib "Extras: Gui-lib (Ultraschall)" ultraschall_gui_lib.lua

--- a/reaper-kb.ini
+++ b/reaper-kb.ini
@@ -405,6 +405,9 @@ SCR 4 0 Ultraschall_SkipLoopPlayback_RetainView_Absolute "Custom: Navigation: Sk
 SCR 4 0 Ultraschall_SaveChapterMarkers_Into_ProjectFolder "Custom: Markers: Save chaptermarkers into project folder(Ultraschall)" ultraschall_save_chapter_markers_into_projectfolder.lua
 SCR 4 0 Ultraschall_SaveChapterMarkers "Custom: Markers: Save chaptermarkers(Ultraschall)" ultraschall_save_chapter_markers.lua
 SCR 4 0 Ultraschall_Duck_Selected_Tracks_Within_Time_Selection_In_PreFX_Volume_Envelope "Envelope: Manual ducking of selected tracks within time-selection(Volume pre fx-envelope)(Ultraschall)" ultraschall_duck_selected_tracks_within_time_selection(volume_prefx-envelope).lua
+SCR 4 0 Ultraschall_Ripple_Cut_Review_Toggle "Settings: Toggle reviewing of edits with Ripple Cut (Ultraschall)" ultraschall_ripple_cut_setting_review_edit_toggle.lua
+SCR 4 0 Ultraschall_Ripple_Cut_Ignore_Locked_Tracks "Settings: Toggle ignoring of locked tracks with Ripple Cut (Ultraschall)" ultraschall_ripple_cut_setting_ignore_locked_tracks_toggle.lua
+SCR 4 0 Ultraschall_Ripple_Cut_Obey_Crossfade "Settings: Toggle obeying of crossfade with Ripple Cut (Ultraschall)" ultraschall_ripple_cut_setting_obey_crossfade.lua
 KEY 9 219 0 0
 KEY 5 116 0 0
 KEY 1 87 0 0

--- a/reaper-kb_windows.ini
+++ b/reaper-kb_windows.ini
@@ -61,7 +61,8 @@ SCR 4 0 Ultraschall_Open_Project_Folder "Custom: ULTRASCHALL: Open project-folde
 SCR 4 0 Ultraschall_Select_StudioLink "Custom: ULTRASCHALL: Select Studiolink" ultraschall_select_studiolink.lua
 SCR 4 0 Ultraschall_Prepare_For_Editing "Custom: ULTRASCHALL: Prepare for editing" ultraschall_prepare_for_editing.lua
 SCR 4 0 Ultraschall_MetaData "Custom: ULTRASCHALL: Metadata" ultraschall_metadata.lua
-SCR 4 0 Ultraschall_Ripple_Cut "Custom: ULTRASCHALL: Ripplecut" ultraschall_ripple_cut.lua
+SCR 4 0 Ultraschall_Ripple_Cut "Time selection: Ripplecut (Ultraschall)" ultraschall_ripplecut_2.0.lua
+SCR 4 0 Ultraschall_Insert_Outtakes_Into_New_Project "Outtakes: Insert Outtakes into new project (Ultraschall)" ultraschall_insert_outtakes.lua
 SCR 4 0 Ultraschall_Toggle_Track_Height "Custom: ULTRASCHALL: Toggle trackheight" ultraschall_toggle_track_height.lua
 SCR 4 0 Ultraschall_Routing_Snapshots_Functions "Custom: ULTRASCHALL: Routing snapshots-functions" ultraschall_routing_snapshots_functions.lua
 SCR 4 0 Ultraschall_Gui_Lib "Custom: ULTRASCHALL: Gui-lib" ultraschall_gui_lib.lua

--- a/reaper-kb_windows.ini
+++ b/reaper-kb_windows.ini
@@ -343,6 +343,9 @@ SCR 4 0 Ultraschall_SkipLoopPlayback_RetainView_Absolute "Custom: Navigation: Sk
 SCR 4 0 Ultraschall_SaveChapterMarkers_Into_ProjectFolder "Custom: Markers: Save chaptermarkers into project folder(Ultraschall)" ultraschall_save_chapter_markers_into_projectfolder.lua
 SCR 4 0 Ultraschall_SaveChapterMarkers "Custom: Markers: Save chaptermarkers(Ultraschall)" ultraschall_save_chapter_markers.lua
 SCR 4 0 Ultraschall_Duck_Selected_Tracks_Within_Time_Selection_In_PreFX_Volume_Envelope "Envelope: Manual ducking of selected tracks within time-selection(Volume pre fx-envelope)(Ultraschall)" ultraschall_duck_selected_tracks_within_time_selection(volume_prefx-envelope).lua
+SCR 4 0 Ultraschall_Ripple_Cut_Review_Toggle "Settings: Toggle reviewing of edits with Ripple Cut (Ultraschall)" ultraschall_ripple_cut_setting_review_edit_toggle.lua
+SCR 4 0 Ultraschall_Ripple_Cut_Ignore_Locked_Tracks "Settings: Toggle ignoring of locked tracks with Ripple Cut (Ultraschall)" ultraschall_ripple_cut_setting_ignore_locked_tracks_toggle.lua
+SCR 4 0 Ultraschall_Ripple_Cut_Obey_Crossfade "Settings: Toggle obeying of crossfade with Ripple Cut (Ultraschall)" ultraschall_ripple_cut_setting_obey_crossfade.lua
 KEY 1 84 0 0
 KEY 5 70 0 0
 KEY 25 32808 0 0


### PR DESCRIPTION
Neues RippleCut, welches weitaus flexibler ist.
- Es erlaubt nun einen Schnitt nochmal abzuhören, nachdem man ihn gemacht hat unter Verwendung der Pre-Roll-Sekunden.
- Es erlaubt auch gelockte Tracks nicht zu ripple-cutten.
- Es ist nun möglich die Cuts als FadeIn/FadeOut oder als Crossfades zu haben
- Geschnittene Items werden im Hintergrund als Outtakes gespeichert, können mit "Outtakes: Insert Outtakes into new project" in ein neues Projekt eingefügt werden.
- Toggle-Actions um die Settings ein und auszuschalten

ultraschall-settings.ini:
```
[ultraschall_settings_ripplecut]
review_edit_toggle=true -- after ripple-cut during playback, always jump back to the edit and replay the edit with pre-roll-time applied   
review_edit_toggle=false -- after ripple-cut during playback, retain playposition for seamless playback(pre 5.1 standard behavior)  

obey_locked_toggle=true -- don't ripple cut locked tracks   
obey_locked_toggle=false -- also ripple cut locked tracks(pre 5.1 standard behavior)  

obey_crossfade_toggle=true -- use crossfade for the edits
obey_crossfade_toggle=false -- use fadeout-fadein for the edits
```