### PR TITLE
Setting für AudioGram zeigt Podcast-Titel

### DIFF
--- a/Scripts/ultraschall_export_audiogram.lua
+++ b/Scripts/ultraschall_export_audiogram.lua
@@ -135,8 +135,13 @@ function checkTimeSelection()
 end
 
 function createTrackNamedAfterID3Title(templateName)
+  local retval, ID3Title
+  if ultraschall.GetUSExternalState("ultraschall_settings_Title_In_AudioGram", "Value", "ultraschall-settings.ini")=="1" then
+	ID3Title=""
+  else
   -- Fetch the project's ID3 Title
-  local retval, ID3Title = reaper.GetSetProjectInfo_String(0, "RENDER_METADATA", "ID3:TIT2", false)
+	retval, ID3Title = reaper.GetSetProjectInfo_String(0, "RENDER_METADATA", "ID3:TIT2", false)
+  end
   
   if not retval or ID3Title == "" then
       ID3Title = " " -- Title is optional
@@ -503,6 +508,8 @@ createAudigramTrack("Insert AudiogramBG track.RTrackTemplate")
 	
 -- Duplicate the track using REAPER's action: "Track: Duplicate tracks"
 -- reaper.Main_OnCommand(40062, 0)
+
+if lol==nil then return end
 
 if ultraschall.IsOS_Windows()==true then
 	renderAudiogramPC()

--- a/Scripts/ultraschall_settings.lua
+++ b/Scripts/ultraschall_settings.lua
@@ -281,7 +281,7 @@ end
 
 
 ------------------------------------------------------
---  Show the GUI menu item. Wird verwendet, um Info-Texte hinter den Buttins anzuzeigen.
+--  Show the GUI menu item. Wird verwendet, um Info-Texte hinter den Buttons anzuzeigen.
 ------------------------------------------------------
 
 function show_menu(str)
@@ -424,7 +424,7 @@ GUI.x, GUI.y = (screen_w - GUI.w) / 2, (screen_h - GUI.h) / 2
 
 
 ------------------------------------------------------
---  Aufbau der nicht interkativen GUI-Elemente wie Logos etc.
+--  Aufbau der nicht interaktiven GUI-Elemente wie Logos etc.
 ------------------------------------------------------
 
 
@@ -524,7 +524,7 @@ function SettingsPageSettings()
 
     if sectionName and string.find(sectionName, "ultraschall_settings", 1) then
       if tonumber(ultraschall.GetUSExternalState(sectionName, "position", "ultraschall-settings.ini"))~=nil then
-        position = header_height + 80 + (tonumber(ultraschall.GetUSExternalState(sectionName,"position", "ultraschall-settings.ini")) * 27) -- Feintuning notwendig
+        position = header_height + 80 + (tonumber(ultraschall.GetUSExternalState(sectionName,"position", "ultraschall-settings.ini")) * 25.5) -- Feintuning notwendig
         settings_Type = ultraschall.GetUSExternalState(sectionName, "settingstype","ultraschall-settings.ini")
   
         if settings_Type == "checkbox" then

--- a/ultraschall-settings.ini
+++ b/ultraschall-settings.ini
@@ -309,6 +309,12 @@ nothing=true
 steps=76
 Value=0.4
 
+[ultraschall_settings_Title_In_AudioGram]
+Description=When set, the AudioGram will not show the title of the podcast.
+name=Don't show Podcast-Title in AudioGram
+position=18
+settingstype=checkbox
+Value=0
 
 [ultraschall_settings_Ultraschall_GUI_Tudelu]
 Value=1


### PR DESCRIPTION
- Es gibt nun ein Setting, mit dem man einstellen kann, ob das AudioGram den Titel des Podcasts anzeigt.
