### PR TITLE
Audiogram und RippleCut

### DIFF
--- a/Scripts/ultraschall_export_audiogram.lua
+++ b/Scripts/ultraschall_export_audiogram.lua
@@ -597,7 +597,7 @@ function InsertBackgroundTrack(startTime, endTime, cover, trackname)
   );]]
 
 VideoCode2=[[//Image overlay
-//@param1:opacity 'opacity' 0.5
+//@param1:opacity 'opacity' 1
 //@param2:zoom 'zoom' 2.4 -15 15 0
 //@param3:xoffs 'X offset' 0.0816 -1 1 0
 //@param4:yoffs 'Y offset' 0 -1 1 0
@@ -622,6 +622,8 @@ img2 != img1 && input_info(img2,sw,sh) ? (
     x = (project_w - dw + (project_w + dw)*xoffs)*.5;
     y = (project_h - dh + (project_h + dh)*yoffs)*.5;
     gfx_blit(img2,0, x|0,y|0,dw,dh);
+    gfx_set(0,0,0,0.5);
+    gfx_fillrect(0,0, project_w, project_h);
   );
 );]]
 

--- a/Scripts/ultraschall_export_audiogram_from_regions.lua
+++ b/Scripts/ultraschall_export_audiogram_from_regions.lua
@@ -627,7 +627,7 @@ function InsertBackgroundTrack(startTime, endTime, cover, trackname)
   );]]
 
 VideoCode2=[[//Image overlay
-//@param1:opacity 'opacity' 0.5
+//@param1:opacity 'opacity' 1
 //@param2:zoom 'zoom' 2.4 -15 15 0
 //@param3:xoffs 'X offset' 0.0816 -1 1 0
 //@param4:yoffs 'Y offset' 0 -1 1 0
@@ -652,6 +652,8 @@ img2 != img1 && input_info(img2,sw,sh) ? (
     x = (project_w - dw + (project_w + dw)*xoffs)*.5;
     y = (project_h - dh + (project_h + dh)*yoffs)*.5;
     gfx_blit(img2,0, x|0,y|0,dw,dh);
+    gfx_set(0,0,0,0.5);
+    gfx_fillrect(0,0, project_w, project_h);
   );
 );]]
 

--- a/Scripts/ultraschall_soundcheck_gui2.lua
+++ b/Scripts/ultraschall_soundcheck_gui2.lua
@@ -392,7 +392,7 @@ function buildGuiWarnings()
 
     end
 
-    gfx.init("", 1000, WindowHeight, 0, GUI.x, GUI.y)
+    --gfx.init("", 1000, WindowHeight, 0, GUI.x, GUI.y)
     GUI.drawnow = true
     rebuild_gui = true
 
@@ -456,7 +456,7 @@ function buildGuiWarnings()
       reaper.atexit(atexitClean)
     else
 
-      gfx.init("", 1000, 170, 0, GUI.x, GUI.y)
+      --gfx.init("", 1000, 170, 0, GUI.x, GUI.y)
       GUI.drawnow = true
       rebuild_gui = true
 

--- a/UserPlugins/ultraschall_api/Modules/ultraschall_functions_MediaItem_Module.lua
+++ b/UserPlugins/ultraschall_api/Modules/ultraschall_functions_MediaItem_Module.lua
@@ -1372,7 +1372,7 @@ function ultraschall.RippleCut(startposition, endposition, trackstring, moveenve
   if moveenvelopepoints==true then
     for i=1, #individual_tracks do
       local MediaTrack=reaper.GetTrack(0,individual_tracks[i]-1)
-      ultraschall.DeleteTrackEnvelopePointsBetween(startposition, endposition, MediaTrack)
+      ultraschall.DeleteTrackEnvelopePointsBetween(startposition, endposition, MediaTrack)  
       ultraschall.MoveTrackEnvelopePointsBy(endposition, reaper.GetProjectLength(), -delta, MediaTrack, false) 
     end
   end
@@ -3801,7 +3801,7 @@ function ultraschall.GetParentTrack_MediaItem(MediaItem)
 <US_DocBloc version="1.0" spok_lang="en" prog_lang="*">
   <slug>GetParentTrack_MediaItem</slug>
   <requires>
-    Ultraschall=4.00
+    Ultraschall=5.2
     Reaper=5.40
     Lua=5.3
   </requires>
@@ -3828,8 +3828,7 @@ function ultraschall.GetParentTrack_MediaItem(MediaItem)
 </US_DocBloc>
 ]]
   if reaper.ValidatePtr2(0, MediaItem, "MediaItem*")==false then ultraschall.AddErrorMessage("GetParentTrack_MediaItem","MediaItem", "Must be a MediaItem!", -1) return -1 end
-  
-  local MediaTrack = reaper.GetMediaItemTake_Track(reaper.GetMediaItemTake(MediaItem,0))
+	MediaTrack = reaper.GetMediaItemInfo_Value(MediaItem, "P_TRACK")
   
   return math.tointeger(reaper.GetMediaTrackInfo_Value(MediaTrack, "IP_TRACKNUMBER")), MediaTrack
 end
@@ -4644,13 +4643,13 @@ end
 function ultraschall.DeleteMediaItemsBetween(startposition, endposition,  trackstring, inside)
 --[[
 <US_DocBloc version="1.0" spok_lang="en" prog_lang="*">
-  <slug>DeleteMediaItems_Position</slug>
+  <slug>DeleteMediaItemsBetween</slug>
   <requires>
     Ultraschall=4.00
     Reaper=5.95
     Lua=5.3
   </requires>
-  <functioncall>boolean retval, array MediaItemStateChunkArray = ultraschall.DeleteMediaItems_Between(number startposition, number endposition, string trackstring, boolean inside)</functioncall>
+  <functioncall>boolean retval, array MediaItemStateChunkArray = ultraschall.DeleteMediaItemsBetween(number startposition, number endposition, string trackstring, boolean inside)</functioncall>
   <description>
     Delete the MediaItems between start- and endposition, from the tracks as given by trackstring.
     Returns also a MediaItemStateChunkArray, that contains the statechunks of all deleted MediaItem


### PR DESCRIPTION
- RippleCut - konnte MediaItems ohne aktive Takes(wie z.B. Text Items) nicht schneiden -> gefixt
- Audiogram - wenn Kapitelmarkenbilder im Projekt vorhanden waren, konnten diese "durchscheinen" in Audiogrammen -> gefixt - danke an Malik Aziz