### PR TITLE
Update ultraschall_ultraclock.lua

### DIFF
--- a/Scripts/ultraschall_ultraclock.lua
+++ b/Scripts/ultraschall_ultraclock.lua
@@ -1017,6 +1017,7 @@ function focus_me()
   if focused==7 and uc_menu[7].checked==false then focused=focused+add end
   --if focused==8 and uc_menu[7].checked==false then focused=focused+1 end
   if focused>8 then focused=1 end
+  if Key==27 then focus=0 reaper.SetCursorContext(1) end
   
   if Key==32 or Key==13 then
     if focused==1 then showmenu(1) 


### PR DESCRIPTION
Wenn Tastaturfokus auf der Uhr ist, ESC setzt Tastaturfokus wieder zurück auf Reaper, so dass Shortcuts funzen.