### PR TITLE
Ultraclock-Highlight Fix

### DIFF
--- a/Scripts/ultraschall_ultraclock.lua
+++ b/Scripts/ultraschall_ultraclock.lua
@@ -987,6 +987,7 @@ function checkhover()
   
   if gfx.mouse_y > lufs_pos_y and 
      gfx.mouse_y < lufs_pos_y+lufs_pos_h and 
+     gfx.mouse_x>0 and
      gfx.mouse_x<(Date_Length[3]) then -- Linksklick auf LUFS-Bereich
     add_color3=0.1
     refresh_me()


### PR DESCRIPTION
Highlighting von Analyze LUFS wurde auch gemacht, wenn man links neben dem Clock-Fenster mit der Maus hoverte -> gefixt
